### PR TITLE
Create assert dependency

### DIFF
--- a/Sources/Dependencies/DependencyValues/Assert.swift
+++ b/Sources/Dependencies/DependencyValues/Assert.swift
@@ -1,0 +1,35 @@
+import XCTestDynamicOverlay
+
+public struct AssertAction {
+  public let action: (@autoclosure () -> Bool, @autoclosure () -> String, StaticString, UInt) -> ()
+
+  public init(action: @escaping (() -> Bool, () -> String, StaticString, UInt) -> Void) {
+    self.action = action
+  }
+
+  @inline(__always)
+  public func callAsFunction(
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    action(condition(), message(), file, line)
+  }
+}
+
+extension DependencyValues {
+  public var assert: AssertAction {
+    get { self[AssertKey.self] }
+    set { self[AssertKey.self] = newValue }
+  }
+
+  private enum AssertKey: DependencyKey {
+    static let liveValue = AssertAction(action: Swift.assert)
+    static let testValue = AssertAction { condition, message, file, line in
+      if !condition() {
+        XCTFail(message(), file: file, line: line)
+      }
+    }
+  }
+}

--- a/Tests/DependenciesTests/AssertTests.swift
+++ b/Tests/DependenciesTests/AssertTests.swift
@@ -1,0 +1,34 @@
+import Dependencies
+import XCTest
+
+final class AssertTests: XCTestCase {
+  @Dependency(\.assert) var assert
+
+  func testTestContext() async throws {
+    let subject = Subject()
+
+    subject.callAssert(condition: true)
+    XCTExpectFailure {
+      subject.callAssert(condition: false)
+    }
+  }
+
+  func testLiveContext() async throws {
+    let subject = withDependencies {
+      $0.context = .live
+    } operation: {
+      Subject()
+    }
+
+    subject.callAssert(condition: true)
+    // Can't test live failure
+  }
+}
+
+final class Subject {
+  @Dependency(\.assert) var assert
+
+  func callAssert(condition: Bool) {
+    self.assert(condition)
+  }
+}


### PR DESCRIPTION
What do you think of adding an `assert` dependency to allow for testable assertions?

If you like the idea I can flesh out the documentation and add `assertionFailure`