### PR TITLE
Capture current dependencies when escaping

### DIFF
--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -353,6 +353,7 @@ extension DependencyValues {
     /// See the docs of ``withEscapedDependencies(_:)-5xvi3`` for more information.
     /// - Parameter operation: A closure which will have access to the propagated dependencies.
     public func yield<R>(_ operation: () throws -> R) rethrows -> R {
+      // TODO: Should `yield` be renamed to `restore`?
       try withDependencies {
         $0 = self.dependencies
       } operation: {

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -326,7 +326,7 @@ public func withDependencies<Model: AnyObject, R>(
 public func withEscapedDependencies<R>(
   _ operation: (DependencyValues.Continuation) throws -> R
 ) rethrows -> R {
-  try operation(DependencyValues.Continuation())
+  try operation(DependencyValues.Continuation(dependencies: ._current))
 }
 
 /// Propagates the current dependencies to an escaping context.
@@ -338,7 +338,7 @@ public func withEscapedDependencies<R>(
 public func withEscapedDependencies<R>(
   _ operation: (DependencyValues.Continuation) async throws -> R
 ) async rethrows -> R {
-  try await operation(DependencyValues.Continuation())
+  try await operation(DependencyValues.Continuation(dependencies: ._current))
 }
 
 extension DependencyValues {
@@ -346,7 +346,7 @@ extension DependencyValues {
   ///
   /// See the docs of ``withEscapedDependencies(_:)-5xvi3`` for more information.
   public struct Continuation: Sendable {
-    @Dependency(\.self) private var dependencies
+    let dependencies: DependencyValues
 
     /// Access the propagated dependencies in an escaping context.
     ///

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -326,7 +326,7 @@ public func withDependencies<Model: AnyObject, R>(
 public func withEscapedDependencies<R>(
   _ operation: (DependencyValues.Continuation) throws -> R
 ) rethrows -> R {
-  try operation(DependencyValues.Continuation(escapedDependencies: ._current))
+  try operation(DependencyValues.Continuation())
 }
 
 /// Propagates the current dependencies to an escaping context.
@@ -338,7 +338,7 @@ public func withEscapedDependencies<R>(
 public func withEscapedDependencies<R>(
   _ operation: (DependencyValues.Continuation) async throws -> R
 ) async rethrows -> R {
-  try await operation(DependencyValues.Continuation(escapedDependencies: ._current))
+  try await operation(DependencyValues.Continuation())
 }
 
 extension DependencyValues {
@@ -347,7 +347,7 @@ extension DependencyValues {
   /// See the docs of ``withEscapedDependencies(_:)-5xvi3`` for more information.
   public struct Continuation: Sendable {
     @Dependency(\.self) var currentDependencies
-    let escapedDependencies: DependencyValues
+    let escapedDependencies = DependencyValues._current
 
     /// Access the propagated dependencies in an escaping context.
     ///

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -346,8 +346,7 @@ extension DependencyValues {
   ///
   /// See the docs of ``withEscapedDependencies(_:)-5xvi3`` for more information.
   public struct Continuation: Sendable {
-    @Dependency(\.self) var currentDependencies
-    let escapedDependencies = DependencyValues._current
+    let dependencies = DependencyValues._current
 
     /// Access the propagated dependencies in an escaping context.
     ///
@@ -355,7 +354,7 @@ extension DependencyValues {
     /// - Parameter operation: A closure which will have access to the propagated dependencies.
     public func yield<R>(_ operation: () throws -> R) rethrows -> R {
       try withDependencies {
-        $0 = self.currentDependencies.merging(self.escapedDependencies)
+        $0 = self.dependencies
       } operation: {
         try operation()
       }
@@ -367,7 +366,7 @@ extension DependencyValues {
     /// - Parameter operation: A closure which will have access to the propagated dependencies.
     public func yield<R>(_ operation: () async throws -> R) async rethrows -> R {
       try await withDependencies {
-        $0 = self.currentDependencies.merging(self.escapedDependencies)
+        $0 = self.dependencies
       } operation: {
         try await operation()
       }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -394,11 +394,11 @@ final class DependencyValuesTests: XCTestCase {
       /*@Published */var value = 0
       @Dependency(\.fullDependency) var fullDependency
       func doSomething(expectation: XCTestExpectation) {
-        withEscapedDependencies { continuation in
-          DispatchQueue.main.async {
-            withDependencies {
-              $0.fullDependency.value = 999
-            } operation: {
+        withDependencies {
+          $0.fullDependency.value = 999
+        } operation: {
+          withEscapedDependencies { continuation in
+            DispatchQueue.main.async {
               continuation.yield {
                 self.value = self.fullDependency.value
                 expectation.fulfill()
@@ -418,7 +418,7 @@ final class DependencyValuesTests: XCTestCase {
     }
     self.wait(for: [expectation], timeout: 1)
     let newValue = await model.value
-    XCTAssertEqual(newValue, 42)
+    XCTAssertEqual(newValue, 999)
   }
 
   func testEscapingInFeatureModelWithOverride_NotPropagated() async {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -386,7 +386,7 @@ final class DependencyValuesTests: XCTestCase {
     self.wait(for: [expectation], timeout: 1)
   }
 
-  func testEscapingInFeatureModelWithOverride_OverrideEscaped() async {
+  func testEscapingInFeatureModelWithOverride_EscapedIsPreferred() async {
     let expectation = self.expectation(description: "escape")
 
     @MainActor

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -386,7 +386,7 @@ final class DependencyValuesTests: XCTestCase {
     self.wait(for: [expectation], timeout: 1)
   }
 
-  func testEscapingInFeatureModelWithOverride_EscapedIsPreferred() async {
+  func testEscapingInFeatureModelWithOverride_OverrideEscaped() async {
     let expectation = self.expectation(description: "escape")
 
     @MainActor
@@ -418,7 +418,7 @@ final class DependencyValuesTests: XCTestCase {
     }
     self.wait(for: [expectation], timeout: 1)
     let newValue = await model.value
-    XCTAssertEqual(newValue, 999)
+    XCTAssertEqual(newValue, 42)
   }
 
   func testEscapingInFeatureModelWithOverride_NotPropagated() async {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -394,12 +394,12 @@ final class DependencyValuesTests: XCTestCase {
       /*@Published */var value = 0
       @Dependency(\.fullDependency) var fullDependency
       func doSomething(expectation: XCTestExpectation) {
-        withDependencies {
-          $0.fullDependency.value = 999
-        } operation: {
-          withEscapedDependencies { continuation in
-            DispatchQueue.main.async {
-              continuation.yield {
+        withEscapedDependencies { continuation in
+          DispatchQueue.main.async {
+            continuation.yield {
+              withDependencies {
+                $0.fullDependency.value = 999
+              } operation: {
                 self.value = self.fullDependency.value
                 expectation.fulfill()
               }


### PR DESCRIPTION
This should fix https://github.com/pointfreeco/swift-composable-architecture/issues/1811.
I don't if this is the behavior you intend for `DependencyValues.Continuation` overall, so feel free to close if we should fix it in TCA instead.

It would perform mostly equivalently to the current implementation in vanilla applications, where nesting is less intense than in TCA, especially if the continuation is yielded as soon as possible in the escaped context.