### PR TITLE
Don't setup observers in non-test contexts.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - protocol-clocks
   workflow_dispatch:
 
 concurrency:

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -327,7 +327,8 @@ private final class CachedValues: @unchecked Sendable {
   #endif
 
   private let setUpTestObservers: Void = {
-    #if canImport(ObjectiveC)
+    if _XCTIsTesting {
+#if canImport(ObjectiveC)
       DispatchQueue.mainSync {
         guard
           let XCTestObservation = objc_getProtocol("XCTestObservation"),
@@ -346,12 +347,13 @@ private final class CachedValues: @unchecked Sendable {
           TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
         class_addProtocol(TestObserver.self, XCTestObservation)
         _ =
-          XCTestObservationCenterShared
+        XCTestObservationCenterShared
           .perform(Selector(("addTestObserver:")), with: TestObserver())
       }
-    #else
+#else
       XCTestObservationCenter.shared.addTestObserver(TestObserver())
-    #endif
+#endif
+    }
   }()
 
   #if canImport(ObjectiveC)

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -328,31 +328,31 @@ private final class CachedValues: @unchecked Sendable {
 
   private let setUpTestObservers: Void = {
     if _XCTIsTesting {
-#if canImport(ObjectiveC)
-      DispatchQueue.mainSync {
-        guard
-          let XCTestObservation = objc_getProtocol("XCTestObservation"),
-          let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
-          let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
-          let XCTestObservationCenterShared =
-            XCTestObservationCenter
-            .perform(Selector(("sharedTestObservationCenter")))?
-            .takeUnretainedValue()
-        else { return }
-        let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
-          DependencyValues._current.cachedValues.cached = [:]
+      #if canImport(ObjectiveC)
+        DispatchQueue.mainSync {
+          guard
+            let XCTestObservation = objc_getProtocol("XCTestObservation"),
+            let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
+            let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
+            let XCTestObservationCenterShared =
+              XCTestObservationCenter
+              .perform(Selector(("sharedTestObservationCenter")))?
+              .takeUnretainedValue()
+          else { return }
+          let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
+            DependencyValues._current.cachedValues.cached = [:]
+          }
+          let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
+          class_addMethod(
+            TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
+          class_addProtocol(TestObserver.self, XCTestObservation)
+          _ =
+            XCTestObservationCenterShared
+            .perform(Selector(("addTestObserver:")), with: TestObserver())
         }
-        let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
-        class_addMethod(
-          TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
-        class_addProtocol(TestObserver.self, XCTestObservation)
-        _ =
-        XCTestObservationCenterShared
-          .perform(Selector(("addTestObserver:")), with: TestObserver())
-      }
-#else
-      XCTestObservationCenter.shared.addTestObserver(TestObserver())
-#endif
+      #else
+        XCTestObservationCenter.shared.addTestObserver(TestObserver())
+      #endif
     }
   }()
 


### PR DESCRIPTION
We ran into an issue of setting up test observers in our Point-Free server code, which is usually just a no-op, but because under the hood it does `DispatchQueue.main.sync` and because the main thread is blocked by NIO, a deadlock occurred. Let's just not set up observers when not in tests.