### PR TITLE
Update DateTests.swift

### DIFF
--- a/Tests/DependenciesTests/DateTests.swift
+++ b/Tests/DependenciesTests/DateTests.swift
@@ -3,15 +3,51 @@ import XCTest
 import XCTestDynamicOverlay
 
 final class DateDependencyTests: XCTestCase {
-  @Dependency(\.date) var date
-  @Dependency(\.date.now) var now
+@Dependency(.date) var date
+@Dependency(.date.now) var now
 
-  func testOverriding_Now() {
-    withDependencies {
-      $0.date.now = Date(timeIntervalSinceReferenceDate: 0)
-    } operation: {
-      XCTAssertEqual(self.now, Date(timeIntervalSinceReferenceDate: 0))
-      XCTAssertEqual(self.date(), Date(timeIntervalSinceReferenceDate: 0))
-    }
-  }
+func testOverriding_Now() {
+withDependencies {
+$0.date.now = Date(timeIntervalSinceReferenceDate: 0)
+} operation: {
+XCTAssertEqual(self.now, Date(timeIntervalSinceReferenceDate: 0))
+XCTAssertEqual(self.date(), Date(timeIntervalSinceReferenceDate: 0))
 }
+}
+
+func testDateComparison() {
+withDependencies {
+$0.date.now = Date(timeIntervalSinceReferenceDate: 0)
+} operation: {
+let date1 = self.date()
+let date2 = self.date()
+XCTAssertLessThan(date1, date2)
+}
+}
+
+func testAddingTimeInterval() {
+withDependencies {
+$0.date.now = Date(timeIntervalSinceReferenceDate: 0)
+} operation: {
+let date = self.date()
+let interval: TimeInterval = 60
+let futureDate = date.addingTimeInterval(interval)
+XCTAssertEqual(futureDate, Date(timeIntervalSinceReferenceDate: interval))
+}
+}
+
+func testChangingTimeZone() {
+withDependencies {
+$0.date.now = Date(timeIntervalSinceReferenceDate: 0)
+} operation: {
+let date = self.date()
+let timeZone = TimeZone(abbreviation: "UTC")!
+let dateInUTC = date.convertToTimeZone(timeZone)
+XCTAssertEqual(dateInUTC.timeZone, timeZone)
+}
+}
+}
+
+
+
+


### PR DESCRIPTION
The script above is a set of test cases for a class that uses the Dependencies' library to test code that relies on the `Date` class. The `Dependency` property wrapper is used to create properties that can be overridden during the test.

The first test case, `testOverriding_Now`, uses the `withDependencies` function to set the `now` property of the` date` dependency to a specific date. The test then asserts that both the `now` property and the `date()` method return that same date.

The second test case, `testDateComparison`, creates two date objects and tests that one is less than the other.

The third test case, `testAddingTimeInterval`, creates a date object and adds a specific time interval to it, then asserts that the resulting date is the same as the date that would be created by the time interval since the reference date.

The fourth test case, `testChangingTimeZone`, creates a date object and changes its time zone to UTC and asserts that the date's time zone is UTC.


> All tests use the `withDependencies` function to set the `now` property of the `date` dependency to a specific date before running the test.