### PR TITLE
Remove unnecessary struct extension

### DIFF
--- a/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
@@ -87,12 +87,7 @@ extension AudioPlayerClient {
 
   static let mock = Self(/* ... */)
 
-  static let unimplemented = Self(
-    loop: unimplemented("AudioPlayerClient.loop"),
-    play: unimplemented("AudioPlayerClient.play"),
-    setVolume: unimplemented("AudioPlayerClient.setVolume"),
-    stop: unimplemented("AudioPlayerClient.stop")
-  )
+  static let unimplemented = Self(/* ... */)
 }
 ```
 
@@ -106,16 +101,18 @@ define the live, preview and test values directly in the conformance, all at onc
 
 ```swift
 extension AudioPlayerClient: DependencyKey {
-  static var live: Self {
+  static var liveValue: Self {
     let audioEngine: AVAudioEngine
     return Self(/*...*/)
   }
 
-  static let mock = Self(/* ... */)
+  static let previewValue = Self(/* ... */)
 
-  static let unimplemented = Self(
+  static let testValue = Self(
     loop: unimplemented("AudioPlayerClient.loop"),
-    // ...
+    play: unimplemented("AudioPlayerClient.play"),
+    setVolume: unimplemented("AudioPlayerClient.setVolume"),
+    stop: unimplemented("AudioPlayerClient.stop")
   )
 }
 

--- a/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
@@ -59,16 +59,6 @@ struct AudioPlayerClient {
 }
 ```
 
-Then, rather than defining types that conform to the protocol you construct values:
-
-```swift
-extension AudioPlayerClient {
-  static let live = Self(/* ... */)
-  static let mock = Self(/* ... */)
-  static let unimplemented = Self(/* ... */)
-}
-```
-
 And to register the dependency you can leverage the struct that defines the interface. There's no
 need to define a new type:
 

--- a/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
@@ -89,10 +89,16 @@ extension AudioPlayerClient {
 
   static let unimplemented = Self(
     loop: unimplemented("AudioPlayerClient.loop"),
-    // ...
+    play: unimplemented("AudioPlayerClient.play"),
+    setVolume: unimplemented("AudioPlayerClient.setVolume"),
+    stop: unimplemented("AudioPlayerClient.stop")
   )
 }
 ```
+
+> Tip: We are using the `unimplemented` method from our 
+[XCTestDynamicOverlay][xctest-dynamic-overlay-gh] library to provide closures that cause an XCTest
+failure if they are ever invoked. See <doc:LivePreviewTest> for more information on this pattern.
 
 Then, to register this dependency you can leverage the `AudioPlayerClient` struct to conform
 to the ``DependencyKey`` protocol. There's no need to define a new type. In fact, you can even 
@@ -160,3 +166,4 @@ user flow you are testing. If someday in the future more of the dependency is us
 instantly get a test failure, letting you know that there is more behavior that you must assert on.
 
 [designing-deps]: https://www.pointfree.co/collections/dependencies
+[xctest-dynamic-overlay-gh]: http://github.com/pointfreeco/xctest-dynamic-overlay


### PR DESCRIPTION
This may be a leftover or an oversight, but correct me if I'm wrong, this docs part is unrelated, and the `DependencyKey` `extension` should be enough.