### PR TITLE
Align URLSession doc to benefit from `liveValue`.

### DIFF
--- a/Sources/Dependencies/DependencyValues/URLSession.swift
+++ b/Sources/Dependencies/DependencyValues/URLSession.swift
@@ -61,8 +61,10 @@ extension DependencyValues {
   ///
   /// ```swift
   /// extension APIClient {
-  ///   static func live(urlSession: URLSession) -> Self {
-  ///     Self(
+  ///   static var liveValue: APIClient {
+  ///     @Dependency(\.urlSession) var urlSession
+  ///
+  ///     return Self(
   ///       fetchProfile: {
   ///         // Use URL session to make request
   ///       }


### PR DESCRIPTION
This is a proposal to to show an example of how to incorporate a dependency within a dependency while still benefiting from the auto `liveValue` injection, without the need to manually inject it with the `.depencency(...)` modifier.