### PR TITLE
Fix default value fallback for Optional-valued dependencies

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -126,7 +126,8 @@ public struct DependencyValues: Sendable {
     line: UInt = #line
   ) -> Key.Value where Key.Value: Sendable {
     get {
-      guard let dependency = self.storage[ObjectIdentifier(key)]?.base as? Key.Value
+      guard let base = self.storage[ObjectIdentifier(key)]?.base,
+            let dependency = base as? Key.Value
       else {
         let context =
           self.storage[ObjectIdentifier(DependencyContextKey.self)]?.base as? DependencyContext
@@ -249,7 +250,7 @@ private final class CachedValues: @unchecked Sendable {
     defer { self.lock.unlock() }
 
     let cacheKey = CacheKey(id: ObjectIdentifier(key), context: context)
-    guard let value = self.cached[cacheKey]?.base as? Key.Value
+    guard let base = self.cached[cacheKey]?.base, let value = base as? Key.Value
     else {
       let value: Key.Value?
       switch context {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -71,6 +71,43 @@ final class DependencyValuesTests: XCTestCase {
     }
   }
 
+  func testOptionalDependency() {
+    for value in [nil, ""] {
+      withDependencies {
+        $0.optionalDependency = value
+      } operation: {
+        @Dependency(\.optionalDependency) var optionalDependency: String?
+        XCTAssertEqual(optionalDependency, value)
+      }
+    }
+  }
+
+  func testOptionalDependencyLive() {
+    withDependencies {
+      $0.context = .live
+    } operation: {
+      @Dependency(\.optionalDependency) var optionalDependency: String?
+      XCTAssertEqual(optionalDependency, "live")
+    }
+
+    withDependencies {
+      $0.context = .live
+      $0.optionalDependency = nil
+    } operation: {
+      @Dependency(\.optionalDependency) var optionalDependency: String?
+      XCTAssertNil(optionalDependency)
+    }
+  }
+
+  func testOptionalDependencyUndefined() {
+    @Dependency(\.optionalDependency) var optionalDependency: String?
+    XCTExpectFailure {
+      XCTAssertNil(optionalDependency)
+    } issueMatcher: {
+      $0.compactDescription.contains(#"Unimplemented: @Dependency(\.optionalDependency) …"#)
+    }
+  }
+
   func testDependencyDefaultIsReused() {
     withDependencies {
       $0 = .init()
@@ -603,6 +640,20 @@ extension DependencyValues {
   var childDependencyLateBinding: ChildDependencyLateBinding {
     get { self[ChildDependencyLateBinding.self] }
     set { self[ChildDependencyLateBinding.self] = newValue }
+  }
+}
+
+extension DependencyValues {
+  var optionalDependency: String? {
+    get { self[OptionalDependencyKey.self] }
+    set { self[OptionalDependencyKey.self] = newValue }
+  }
+}
+
+private enum OptionalDependencyKey: DependencyKey {
+  static let liveValue: String? = "live"
+  static var testValue: String? {
+    unimplemented(#"@Dependency(\.optionalDependency)"#, placeholder: nil)
   }
 }
 

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -99,6 +99,7 @@ final class DependencyValuesTests: XCTestCase {
     }
   }
 
+  #if !os(Linux)
   func testOptionalDependencyUndefined() {
     @Dependency(\.optionalDependency) var optionalDependency: String?
     XCTExpectFailure {
@@ -107,6 +108,7 @@ final class DependencyValuesTests: XCTestCase {
       $0.compactDescription.contains(#"Unimplemented: @Dependency(\.optionalDependency) …"#)
     }
   }
+  #endif
 
   func testDependencyDefaultIsReused() {
     withDependencies {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -99,7 +99,7 @@ final class DependencyValuesTests: XCTestCase {
     }
   }
 
-  #if !os(Linux)
+  #if DEBUG && !os(Linux)
   func testOptionalDependencyUndefined() {
     @Dependency(\.optionalDependency) var optionalDependency: String?
     XCTExpectFailure {


### PR DESCRIPTION
The `liveValue`/`previewValue`/`testValue` fallback mechanism is currently bypassed for dependencies which have an `associatedtype Value` of `Optional<_>` type. The logic confuses no value found in  `storage` for a valid value (`nil: Value`) found, and never ends up picking up the task-local default:

```swift
extension DependencyValues {
  var optionalDependency: String? {
    get { self[OptionalDependencyKey.self] }
    set { self[OptionalDependencyKey.self] = newValue }
  }
}

private enum OptionalDependencyKey: DependencyKey {
  static let liveValue: String? = "live"  // ⚠️ never returned!
  static var testValue: String? {         // ⚠️ never evaluated!
    unimplemented(#"@Dependency(\.optionalDependency)"#, placeholder: nil)
  }
}

// ⚠️ defaults `nil` no matter what!
@Dependency(\.optionalDependency) var optionalDependency: String?
```

This PR adds a a few unit test cases exposing the faulty behaviour and makes the fixes to correct it.