### PR TITLE
Add a reference to Weaver to the "Alternatives" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ priorities and trade-offs that differ from Dependencies. Here are a few well-kno
   * [Factory](https://github.com/hmlongco/Factory)
   * [Needle](https://github.com/uber/needle)
   * [Swinject](https://github.com/Swinject/Swinject)
+  * [Weaver](https://github.com/scribd/Weaver)
 
 ## License
 


### PR DESCRIPTION
GitHub just suggested me this 700 stars dependency-injection repo that I wasn't aware of. It looks rather complex, with some bits of codegen, but it also uses modern Swift features like property wrappers. I seems to fit in this section.