### PR TITLE
Add a `isEmpty` property to `DependencyValues`

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -85,6 +85,7 @@ public struct DependencyValues: Sendable {
   @TaskLocal static var currentDependency = CurrentDependency()
 
   fileprivate var cachedValues = CachedValues()
+  @_spi(Internals) public var isEmpty: Bool { self.storage.isEmpty }
   private var storage: [ObjectIdentifier: AnySendable] = [:]
 
   /// Creates a dependency values instance.

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -1,4 +1,4 @@
-import Dependencies
+@_spi(Internals) import Dependencies
 import XCTest
 
 final class DependencyValuesTests: XCTestCase {
@@ -591,6 +591,22 @@ final class DependencyValuesTests: XCTestCase {
       XCTAssertEqual(value, 1)
     }
   #endif
+  
+  func testIsEmpty() {
+    @Dependency(\.self) var dependencies
+    
+    XCTAssertTrue(dependencies.isEmpty)
+    
+    withDependencies { _ in () } operation: {
+      XCTAssertTrue(dependencies.isEmpty)
+    }
+    
+    withDependencies {
+      $0.date = .constant(.now)
+    } operation: {
+      XCTAssertFalse(dependencies.isEmpty)
+    }
+  }
 }
 
 actor CachedDependency: TestDependencyKey {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -593,7 +593,7 @@ final class DependencyValuesTests: XCTestCase {
   #endif
 
   func testIsEmpty() {
-    @Dependency(\.self) var dependencies;
+    @Dependency(\.self) var dependencies: DependencyValues
 
     XCTAssertTrue(dependencies.isEmpty)
 

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -602,7 +602,7 @@ final class DependencyValuesTests: XCTestCase {
     }
     
     withDependencies {
-      $0.date = .constant(.now)
+      $0.context = .preview
     } operation: {
       XCTAssertFalse(dependencies.isEmpty)
     }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -598,7 +598,6 @@ final class DependencyValuesTests: XCTestCase {
     XCTAssertTrue(dependencies.isEmpty)
 
     withDependencies { _ in
-      ()
     } operation: {
       XCTAssertTrue(dependencies.isEmpty)
     }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -591,16 +591,18 @@ final class DependencyValuesTests: XCTestCase {
       XCTAssertEqual(value, 1)
     }
   #endif
-  
+
   func testIsEmpty() {
-    @Dependency(\.self) var dependencies
-    
+    @Dependency(\.self) var dependencies;
+
     XCTAssertTrue(dependencies.isEmpty)
-    
-    withDependencies { _ in () } operation: {
+
+    withDependencies { _ in
+      ()
+    } operation: {
       XCTAssertTrue(dependencies.isEmpty)
     }
-    
+
     withDependencies {
       $0.context = .preview
     } operation: {


### PR DESCRIPTION
This PR adds an `isEmpty` property to `DependencyValues` that reflects the current storage's state. 
This property can be used to detect if the current context has dependencies with non-default values, as it was potentially discussed on [Slack](https://pointfreecommunity.slack.com/archives/C04L2D0MNJH/p1676982334184199).
This property, which reflects some internal implementation state, is hidden behind `@_spi`, so it furthermore doesn't appear in `@Dependency(\.…)` `KeyPath` autocompletion.
As an alternative, it can directly be installed as a static property that would only reflect `Self._current`'s internal storage state. Let me know if you prefer it this way instead.