### PR TITLE
Modernize a few tests

### DIFF
--- a/Sources/Dependencies/Internal/RuntimeWarnings.swift
+++ b/Sources/Dependencies/Internal/RuntimeWarnings.swift
@@ -1,3 +1,4 @@
+import Foundation
 @_transparent
 @usableFromInline
 @inline(__always)

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -392,7 +392,11 @@ final class DependencyValuesTests: XCTestCase {
     }
 
     await model.doSomething(expectation: expectation)
-    await self.fulfillment(of: [expectation], timeout: 1)
+    #if !os(Linux)
+      await self.fulfillment(of: [expectation], timeout: 1)
+    #else
+      self.wait(for: [expectation], timeout: 1)
+    #endif
     let newValue = await model.value
     XCTAssertEqual(newValue, 3)
   }
@@ -422,7 +426,11 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    await self.fulfillment(of: [expectation], timeout: 1)
+    #if !os(Linux)
+      await self.fulfillment(of: [expectation], timeout: 1)
+    #else
+      self.wait(for: [expectation], timeout: 1)
+    #endif
   }
 
   func testEscapingInFeatureModelWithOverride_OverrideEscaped() async {
@@ -455,7 +463,11 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    await self.fulfillment(of: [expectation], timeout: 1)
+    #if !os(Linux)
+      await self.fulfillment(of: [expectation], timeout: 1)
+    #else
+      self.wait(for: [expectation], timeout: 1)
+    #endif
     let newValue = await model.value
     XCTAssertEqual(newValue, 999)
   }
@@ -482,7 +494,11 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    await self.fulfillment(of: [expectation], timeout: 1)
+    #if !os(Linux)
+      await self.fulfillment(of: [expectation], timeout: 1)
+    #else
+      self.wait(for: [expectation], timeout: 1)
+    #endif
     let newValue = await model.value
     XCTAssertEqual(newValue, 3)
   }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -392,7 +392,7 @@ final class DependencyValuesTests: XCTestCase {
     }
 
     await model.doSomething(expectation: expectation)
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
     let newValue = await model.value
     XCTAssertEqual(newValue, 3)
   }
@@ -422,7 +422,7 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
   }
 
   func testEscapingInFeatureModelWithOverride_OverrideEscaped() async {
@@ -455,7 +455,7 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
     let newValue = await model.value
     XCTAssertEqual(newValue, 999)
   }
@@ -482,7 +482,7 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
     let newValue = await model.value
     XCTAssertEqual(newValue, 3)
   }


### PR DESCRIPTION
Xcode 14.3 shows only a few new warnings that seem easy to fix.
On occurrence will need `import Foundation` in Swift 6 to conform `String` to `CVarArg`.
The other changes are upgrades from `wait(for: expectations)` to `await fulfillment(of: expectations)` on Apple platforms.