### PR TITLE
Simplify the `OpenURLEffect.liveValue` implementation.

### DIFF
--- a/Tests/DependenciesTests/OpenURLTests.swift
+++ b/Tests/DependenciesTests/OpenURLTests.swift
@@ -4,45 +4,44 @@ import XCTestDynamicOverlay
 
 final class OpenURLTests: XCTestCase {
   func testOpenUrl() async {
-      let urlToOpenIsolated = ActorIsolated<URL?>(nil)
+    let urlToOpenIsolated = ActorIsolated<URL?>(nil)
 
-      let viewModel = withDependencies {
-          $0.openURL = .init { url in
-              await urlToOpenIsolated.setValue(url)
-              return true
-          }
-      } operation: {
-          ViewModel()
+    let viewModel = withDependencies {
+      $0.openURL = .init { url in
+        await urlToOpenIsolated.setValue(url)
+        return true
       }
+    } operation: {
+      ViewModel()
+    }
 
-      var urlToOpen = await urlToOpenIsolated.value
-      XCTAssertNil(urlToOpen)
+    var urlToOpen = await urlToOpenIsolated.value
+    XCTAssertNil(urlToOpen)
 
-      await viewModel.openMailApp()
-      urlToOpen = await urlToOpenIsolated.value
-      XCTAssertEqual(urlToOpen, .mailApp)
+    await viewModel.openMailApp()
+    urlToOpen = await urlToOpenIsolated.value
+    XCTAssertEqual(urlToOpen, .mailApp)
 
-      await viewModel.openSomeUrl()
-      urlToOpen = await urlToOpenIsolated.value
-      XCTAssertEqual(urlToOpen, URL(string: "https://example.com"))
+    await viewModel.openSomeUrl()
+    urlToOpen = await urlToOpenIsolated.value
+    XCTAssertEqual(urlToOpen, URL(string: "https://example.com"))
   }
 }
 
 private final class ViewModel {
-    @Dependency(\.openURL) var openURL
+  @Dependency(\.openURL) var openURL
 
-    func openMailApp() async {
-        await openURL(.mailApp)
-    }
+  func openMailApp() async {
+    await openURL(.mailApp)
+  }
 
-    func openSomeUrl() async {
-        await openURL(URL(string: "https://example.com")!)
-    }
+  func openSomeUrl() async {
+    await openURL(URL(string: "https://example.com")!)
+  }
 }
 
-
 extension URL {
-    fileprivate static var mailApp: Self {
-        URL(string: "message://")!
-    }
+  fileprivate static var mailApp: Self {
+    URL(string: "message://")!
+  }
 }

--- a/Tests/DependenciesTests/OpenURLTests.swift
+++ b/Tests/DependenciesTests/OpenURLTests.swift
@@ -1,0 +1,48 @@
+import Dependencies
+import XCTest
+import XCTestDynamicOverlay
+
+final class OpenURLTests: XCTestCase {
+  func testOpenUrl() async {
+      let urlToOpenIsolated = ActorIsolated<URL?>(nil)
+
+      let viewModel = withDependencies {
+          $0.openURL = .init { url in
+              await urlToOpenIsolated.setValue(url)
+              return true
+          }
+      } operation: {
+          ViewModel()
+      }
+
+      var urlToOpen = await urlToOpenIsolated.value
+      XCTAssertNil(urlToOpen)
+
+      await viewModel.openMailApp()
+      urlToOpen = await urlToOpenIsolated.value
+      XCTAssertEqual(urlToOpen, .mailApp)
+
+      await viewModel.openSomeUrl()
+      urlToOpen = await urlToOpenIsolated.value
+      XCTAssertEqual(urlToOpen, URL(string: "https://example.com"))
+  }
+}
+
+private final class ViewModel {
+    @Dependency(\.openURL) var openURL
+
+    func openMailApp() async {
+        await openURL(.mailApp)
+    }
+
+    func openSomeUrl() async {
+        await openURL(URL(string: "https://example.com")!)
+    }
+}
+
+
+extension URL {
+    fileprivate static var mailApp: Self {
+        URL(string: "message://")!
+    }
+}


### PR DESCRIPTION
# Changelog
- Simplify the `OpenURLEffect.liveValue` implementation using `withCheckedContinuation`.
- Added `OpenURLTests`

Hello, While looking at the implementation of `OpenURLEffect` and noticed that it's using the `AsyncStream` and grabbing the first element and discarding rest. In this instance, `withCheckedContinuation` should be sufficient to covert the closure into async API.

Thanks for taking a look.