### PR TITLE
constrain TestDependencyKey associatedtype to Sendable

### DIFF
--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -118,7 +118,7 @@ public protocol DependencyKey: TestDependencyKey {
 /// return a default value suitable for Xcode previews, or the ``testValue``, if left unimplemented.
 ///
 /// See ``DependencyKey`` to define a static, default value for the live application.
-public protocol TestDependencyKey: Sendable where Value: Sendable {
+public protocol TestDependencyKey {
   /// The associated type representing the type of the dependency key's value.
 	associatedtype Value = Self
 

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -118,12 +118,9 @@ public protocol DependencyKey: TestDependencyKey {
 /// return a default value suitable for Xcode previews, or the ``testValue``, if left unimplemented.
 ///
 /// See ``DependencyKey`` to define a static, default value for the live application.
-public protocol TestDependencyKey {
+public protocol TestDependencyKey: Sendable where Value: Sendable {
   /// The associated type representing the type of the dependency key's value.
-  associatedtype Value = Self
-
-  // NB: This associated type should be constrained to `Sendable` when this bug is fixed:
-  //     https://github.com/apple/swift/issues/60649
+	associatedtype Value = Self
 
   /// The preview value for the dependency key.
   ///

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -120,7 +120,13 @@ public protocol DependencyKey: TestDependencyKey {
 /// See ``DependencyKey`` to define a static, default value for the live application.
 public protocol TestDependencyKey {
   /// The associated type representing the type of the dependency key's value.
-	associatedtype Value = Self
+  #if swift(>=5.7.1)
+    associatedtype Value: Sendable = Self
+  #else
+    // NB: Can't constrain to `Sendable` on earlier Swift versions due to this bug:
+    //     https://github.com/apple/swift/issues/60649
+    associatedtype Value = Self
+  #endif
 
   /// The preview value for the dependency key.
   ///


### PR DESCRIPTION
This seems to be fixed: https://github.com/apple/swift/issues/60649
running swiftlang-5.7.2.135.5 clang-1400.0.29.51
