### PR TITLE
Use `DependencyValues.$_current.withValue(dependencies)` to compute `wrappedValue`

### DIFF
--- a/Sources/Dependencies/Dependency.swift
+++ b/Sources/Dependencies/Dependency.swift
@@ -92,10 +92,16 @@ public struct Dependency<Value>: @unchecked Sendable, _HasInitialValues {
       currentDependency.fileID = self.fileID
       currentDependency.line = self.line
       return DependencyValues.$currentDependency.withValue(currentDependency) {
-        self.initialValues.merging(DependencyValues._current)[keyPath: self.keyPath]
+        let dependencies = self.initialValues.merging(DependencyValues._current)
+        return DependencyValues.$_current.withValue(dependencies) {
+          DependencyValues._current[keyPath: self.keyPath]
+        }
       }
     #else
-      return self.initialValues.merging(DependencyValues._current)[keyPath: self.keyPath]
+      let dependencies = self.initialValues.merging(DependencyValues._current)
+      return DependencyValues.$_current.withValue(dependencies) {
+        DependencyValues._current[keyPath: self.keyPath]
+      }
     #endif
   }
 }

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -95,9 +95,7 @@ public struct DependencyValues: Sendable {
   /// provide access only to default values. Instead, you rely on the dependency values' instance
   /// that the library manages for you when you use the ``Dependency`` property wrapper.
   public init() {
-    #if DEBUG
-      _ = setUpTestObservers
-    #endif
+    _ = setUpTestObservers
   }
 
   /// Accesses the dependency value associated with a custom key.
@@ -275,7 +273,7 @@ private final class CachedValues: @unchecked Sendable {
   ) -> Key.Value where Key.Value: Sendable {
     self.lock.lock()
     defer { self.lock.unlock() }
- 
+
     let cacheKey = CacheKey(id: ObjectIdentifier(key), context: context)
     guard let base = self.cached[cacheKey]?.base, let value = base as? Key.Value
     else {
@@ -351,62 +349,60 @@ private final class CachedValues: @unchecked Sendable {
 
 // NB: We cannot statically link/load XCTest on Apple platforms, so we dynamically load things
 //     instead and we limit this to debug builds to avoid App Store binary rejection.
-#if DEBUG
-  #if !canImport(ObjectiveC)
-    import XCTest
-  #endif
+#if !canImport(ObjectiveC)
+  import XCTest
+#endif
 
-  private let setUpTestObservers: Void = {
-    if _XCTIsTesting {
-      #if canImport(ObjectiveC)
-        DispatchQueue.mainSync {
-          guard
-            let XCTestObservation = objc_getProtocol("XCTestObservation"),
-            let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
-            let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
-            let XCTestObservationCenterShared =
-              XCTestObservationCenter
-              .perform(Selector(("sharedTestObservationCenter")))?
-              .takeUnretainedValue()
-          else { return }
-          let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
-            DependencyValues._current.cachedValues.cached = [:]
-          }
-          let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
-          class_addMethod(
-            TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
-          class_addProtocol(TestObserver.self, XCTestObservation)
-          _ =
-            XCTestObservationCenterShared
-            .perform(Selector(("addTestObserver:")), with: TestObserver())
+private let setUpTestObservers: Void = {
+  if _XCTIsTesting {
+    #if canImport(ObjectiveC)
+      DispatchQueue.mainSync {
+        guard
+          let XCTestObservation = objc_getProtocol("XCTestObservation"),
+          let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
+          let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
+          let XCTestObservationCenterShared =
+            XCTestObservationCenter
+            .perform(Selector(("sharedTestObservationCenter")))?
+            .takeUnretainedValue()
+        else { return }
+        let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
+          DependencyValues._current.cachedValues.cached = [:]
         }
-      #else
-        XCTestObservationCenter.shared.addTestObserver(TestObserver())
-      #endif
-    }
-  }()
-
-  #if canImport(ObjectiveC)
-    private final class TestObserver: NSObject {}
-  #else
-    private final class TestObserver: NSObject, XCTestObservation {
-      func testCaseWillStart(_ testCase: XCTestCase) {
-        DependencyValues._current.cachedValues.cached = [:]
+        let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
+        class_addMethod(
+          TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
+        class_addProtocol(TestObserver.self, XCTestObservation)
+        _ =
+          XCTestObservationCenterShared
+          .perform(Selector(("addTestObserver:")), with: TestObserver())
       }
-    }
-  #endif
+    #else
+      XCTestObservationCenter.shared.addTestObserver(TestObserver())
+    #endif
+  }
+}()
 
-  extension DispatchQueue {
-    private static let key = DispatchSpecificKey<UInt8>()
-    private static let value: UInt8 = 0
-
-    fileprivate static func mainSync<R>(execute block: @Sendable () -> R) -> R {
-      Self.main.setSpecific(key: Self.key, value: Self.value)
-      if getSpecific(key: Self.key) == Self.value {
-        return block()
-      } else {
-        return Self.main.sync(execute: block)
-      }
+#if canImport(ObjectiveC)
+  private final class TestObserver: NSObject {}
+#else
+  private final class TestObserver: NSObject, XCTestObservation {
+    func testCaseWillStart(_ testCase: XCTestCase) {
+      DependencyValues._current.cachedValues.cached = [:]
     }
   }
 #endif
+
+extension DispatchQueue {
+  private static let key = DispatchSpecificKey<UInt8>()
+  private static let value: UInt8 = 0
+
+  fileprivate static func mainSync<R>(execute block: @Sendable () -> R) -> R {
+    Self.main.setSpecific(key: Self.key, value: Self.value)
+    if getSpecific(key: Self.key) == Self.value {
+      return block()
+    } else {
+      return Self.main.sync(execute: block)
+    }
+  }
+}

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -275,7 +275,7 @@ private final class CachedValues: @unchecked Sendable {
   ) -> Key.Value where Key.Value: Sendable {
     self.lock.lock()
     defer { self.lock.unlock() }
-
+ 
     let cacheKey = CacheKey(id: ObjectIdentifier(key), context: context)
     guard let base = self.cached[cacheKey]?.base, let value = base as? Key.Value
     else {

--- a/Tests/DependenciesTests/ResolutionTests.swift
+++ b/Tests/DependenciesTests/ResolutionTests.swift
@@ -17,6 +17,29 @@ final class ResolutionTests: XCTestCase {
     }
   }
 
+  func testDependencyWithInitialValuesDependingOnDependency_Eager() {
+    struct Model {
+      @Dependency(\.eagerParent) var eagerParent: EagerParentDependency
+      @Dependency(\.eagerChild) var eagerChild: EagerChildDependency
+    }
+
+    let model = withDependencies {
+      $0.eagerChild.value = 1
+    } operation: {
+      Model()
+    }
+
+    XCTAssertEqual(model.eagerParent.value, 1)
+    XCTAssertEqual(model.eagerChild.value, 1)
+
+    withDependencies {
+      $0.eagerChild.value = 42
+    } operation: {
+      XCTAssertEqual(model.eagerParent.value, 1)
+      XCTAssertEqual(model.eagerChild.value, 42)
+    }
+  }
+
   func testDependencyDependingOnDependency_Lazy() {
     @Dependency(\.lazyParent) var lazyParent: LazyParentDependency
     @Dependency(\.lazyChild) var lazyChild: LazyChildDependency

--- a/Tests/DependenciesTests/ResolutionTests.swift
+++ b/Tests/DependenciesTests/ResolutionTests.swift
@@ -54,19 +54,92 @@ final class ResolutionTests: XCTestCase {
     }
 
     let model = withDependencies {
-      $0.nestedChild.value = 1
+      $0.nestedChild.value = { 1 }
     } operation: {
       Model()
     }
 
-    XCTAssertEqual(model.nestedParent.value, 1)
-    XCTAssertEqual(model.nestedChild.value, 1)
+    XCTAssertEqual(model.nestedParent.value(), 1)
+    XCTAssertEqual(model.nestedChild.value(), 1)
 
     withDependencies {
-      $0.nestedChild.value = 42
+      $0.nestedChild.value = { 42 }
     } operation: {
-      XCTAssertEqual(model.nestedParent.value, 42)
-      XCTAssertEqual(model.nestedChild.value, 42)
+      XCTAssertEqual(model.nestedParent.value(), 42)
+      XCTAssertEqual(model.nestedChild.value(), 42)
+    }
+  }
+
+  func testFirstAccessBehavior() {
+    @Dependency(\.nestedParent) var nestedParent: NestedParentDependency
+    struct Model {
+      @Dependency(\.nestedParent) var nestedParent: NestedParentDependency
+      @Dependency(\.nestedChild) var nestedChild: NestedChildDependency
+    }
+
+    let model = withDependencies {
+      $0.nestedChild.value = { 1 }
+    } operation: {
+      Model()
+    }
+
+    XCTAssertEqual(nestedParent.value(), 1729)
+    XCTAssertEqual(model.nestedParent.value(), 1729)
+    XCTAssertEqual(model.nestedChild.value(), 1)
+
+    withDependencies {
+      $0.nestedChild.value = { 42 }
+    } operation: {
+      XCTAssertEqual(model.nestedParent.value(), 42)
+      XCTAssertEqual(model.nestedChild.value(), 42)
+    }
+  }
+
+  func testParentChildScoping() {
+    withDependencies {
+      $0.context = .live
+    } operation: {
+      @Dependency(\.date) var date
+      let _ = date.now
+
+      class ParentModel {
+        @Dependency(\.date) var date
+        var child1: Child1Model?
+        var child2: Child2Model?
+        func goToChild1() {
+          self.child1 = withDependencies(from: self) { Child1Model() }
+        }
+        func goToChild2() {
+          self.child2 = withDependencies(from: self) { Child2Model() }
+        }
+      }
+      class Child1Model {
+        @Dependency(\.date) var date
+      }
+      class Child2Model {
+        @Dependency(\.date) var date
+      }
+
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 1))
+      } operation: {
+        ParentModel()
+      }
+
+      withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 2))
+      } operation: {
+        model.goToChild1()
+      }
+      withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 3))
+      } operation: {
+        model.goToChild2()
+      }
+
+      XCTAssertEqual(model.date.now.timeIntervalSince1970, 1)
+      XCTAssertEqual(model.child1?.date.now.timeIntervalSince1970, 2)
+      XCTAssertEqual(model.child2?.date.now.timeIntervalSince1970, 3)
     }
   }
 
@@ -135,13 +208,17 @@ private struct LazyChildDependency: TestDependencyKey {
   static let testValue = Self { 1729 }
 }
 private struct NestedParentDependency: TestDependencyKey {
-  @Dependency(\.nestedChild) var child
-  var value: Int { self.child.value }
-  static var testValue = Self()
+  var value: () -> Int
+  static var testValue: NestedParentDependency {
+    @Dependency(\.nestedChild) var child
+    return Self {
+      return child.value()
+    }
+  }
 }
 private struct NestedChildDependency: TestDependencyKey {
-  var value: Int
-  static var testValue = Self(value: 1729)
+  var value: () -> Int
+  static let testValue = Self { 1729 }
 }
 private struct DiamondDependencyA: TestDependencyKey {
   var value: @Sendable () -> Int


### PR DESCRIPTION
This PR aims to allow a dependency nested inside another dependency to inherit the initialValues from its ancestor.

I ran into an issue while trying to override a dependency on a model. I'm unsure if my expectations are correct though. So feel free to close this PR if the behaviour is as intended. Here is a simplified example of my use case:

```swift
struct AppBundle: DependencyKey {
  var version: () -> String
  static var liveValue = Self {
    Bundle.main.infoDictionary?["CFBundleShortVersionString"].map { "\($0)" } ?? ""
  }
}

struct Client: DependencyKey {
  @Dependency(\.bundle) private var bundle
  var version: String { self.bundle.version() }
  static var liveValue = Self()
}

class AppModel: ObservableObject {
  @Dependency(\.client) var client
}

struct ContentView: View {
  @StateObject var model = withDependencies {
    $0.bundle.version = { "0.2.0" }
  } operation: {
    AppModel()
  }

  var body: some View {
    Text(model.client.version)
  }
}
```