### PR TITLE
Import Foundation in RuntimeWarnings and update test expectation methods

### DIFF
--- a/Sources/Dependencies/Internal/RuntimeWarnings.swift
+++ b/Sources/Dependencies/Internal/RuntimeWarnings.swift
@@ -35,6 +35,7 @@ func runtimeWarn(
 #if DEBUG
   #if canImport(os)
     import os
+    import Foundation
 
     // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
     //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -392,7 +392,7 @@ final class DependencyValuesTests: XCTestCase {
     }
 
     await model.doSomething(expectation: expectation)
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
     let newValue = await model.value
     XCTAssertEqual(newValue, 3)
   }
@@ -422,7 +422,7 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
   }
 
   func testEscapingInFeatureModelWithOverride_OverrideEscaped() async {
@@ -455,7 +455,7 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
     let newValue = await model.value
     XCTAssertEqual(newValue, 999)
   }
@@ -482,7 +482,7 @@ final class DependencyValuesTests: XCTestCase {
     } operation: {
       await model.doSomething(expectation: expectation)
     }
-    self.wait(for: [expectation], timeout: 1)
+    await self.fulfillment(of: [expectation], timeout: 1)
     let newValue = await model.value
     XCTAssertEqual(newValue, 3)
   }


### PR DESCRIPTION
New warning with Xcode 14.3 about not having access to Swift.String's CVarArgs conformance without the Foundation import. And using async specific expectation waiting method that is now a warning in Xcode 14.3
