### PR TITLE
Revert "remove #if DEBUG guard"

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -95,7 +95,9 @@ public struct DependencyValues: Sendable {
   /// provide access only to default values. Instead, you rely on the dependency values' instance
   /// that the library manages for you when you use the ``Dependency`` property wrapper.
   public init() {
-    _ = setUpTestObservers
+    #if DEBUG
+      _ = setUpTestObservers
+    #endif
   }
 
   /// Accesses the dependency value associated with a custom key.
@@ -273,7 +275,7 @@ private final class CachedValues: @unchecked Sendable {
   ) -> Key.Value where Key.Value: Sendable {
     self.lock.lock()
     defer { self.lock.unlock() }
-
+ 
     let cacheKey = CacheKey(id: ObjectIdentifier(key), context: context)
     guard let base = self.cached[cacheKey]?.base, let value = base as? Key.Value
     else {
@@ -349,60 +351,62 @@ private final class CachedValues: @unchecked Sendable {
 
 // NB: We cannot statically link/load XCTest on Apple platforms, so we dynamically load things
 //     instead and we limit this to debug builds to avoid App Store binary rejection.
-#if !canImport(ObjectiveC)
-  import XCTest
-#endif
+#if DEBUG
+  #if !canImport(ObjectiveC)
+    import XCTest
+  #endif
 
-private let setUpTestObservers: Void = {
-  if _XCTIsTesting {
-    #if canImport(ObjectiveC)
-      DispatchQueue.mainSync {
-        guard
-          let XCTestObservation = objc_getProtocol("XCTestObservation"),
-          let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
-          let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
-          let XCTestObservationCenterShared =
-            XCTestObservationCenter
-            .perform(Selector(("sharedTestObservationCenter")))?
-            .takeUnretainedValue()
-        else { return }
-        let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
-          DependencyValues._current.cachedValues.cached = [:]
+  private let setUpTestObservers: Void = {
+    if _XCTIsTesting {
+      #if canImport(ObjectiveC)
+        DispatchQueue.mainSync {
+          guard
+            let XCTestObservation = objc_getProtocol("XCTestObservation"),
+            let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
+            let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
+            let XCTestObservationCenterShared =
+              XCTestObservationCenter
+              .perform(Selector(("sharedTestObservationCenter")))?
+              .takeUnretainedValue()
+          else { return }
+          let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
+            DependencyValues._current.cachedValues.cached = [:]
+          }
+          let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
+          class_addMethod(
+            TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
+          class_addProtocol(TestObserver.self, XCTestObservation)
+          _ =
+            XCTestObservationCenterShared
+            .perform(Selector(("addTestObserver:")), with: TestObserver())
         }
-        let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
-        class_addMethod(
-          TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
-        class_addProtocol(TestObserver.self, XCTestObservation)
-        _ =
-          XCTestObservationCenterShared
-          .perform(Selector(("addTestObserver:")), with: TestObserver())
-      }
-    #else
-      XCTestObservationCenter.shared.addTestObserver(TestObserver())
-    #endif
-  }
-}()
+      #else
+        XCTestObservationCenter.shared.addTestObserver(TestObserver())
+      #endif
+    }
+  }()
 
-#if canImport(ObjectiveC)
-  private final class TestObserver: NSObject {}
-#else
-  private final class TestObserver: NSObject, XCTestObservation {
-    func testCaseWillStart(_ testCase: XCTestCase) {
-      DependencyValues._current.cachedValues.cached = [:]
+  #if canImport(ObjectiveC)
+    private final class TestObserver: NSObject {}
+  #else
+    private final class TestObserver: NSObject, XCTestObservation {
+      func testCaseWillStart(_ testCase: XCTestCase) {
+        DependencyValues._current.cachedValues.cached = [:]
+      }
+    }
+  #endif
+
+  extension DispatchQueue {
+    private static let key = DispatchSpecificKey<UInt8>()
+    private static let value: UInt8 = 0
+
+    fileprivate static func mainSync<R>(execute block: @Sendable () -> R) -> R {
+      Self.main.setSpecific(key: Self.key, value: Self.value)
+      if getSpecific(key: Self.key) == Self.value {
+        return block()
+      } else {
+        return Self.main.sync(execute: block)
+      }
     }
   }
 #endif
-
-extension DispatchQueue {
-  private static let key = DispatchSpecificKey<UInt8>()
-  private static let value: UInt8 = 0
-
-  fileprivate static func mainSync<R>(execute block: @Sendable () -> R) -> R {
-    Self.main.setSpecific(key: Self.key, value: Self.value)
-    if getSpecific(key: Self.key) == Self.value {
-      return block()
-    } else {
-      return Self.main.sync(execute: block)
-    }
-  }
-}


### PR DESCRIPTION
This reverts commit cfdddbc569638fceb501ceca81ef6a23e490c311.

Fixes #79 

This isn't a complete fix in the sense that

```
docker run --rm -v "$PWD":/host -w /host swift:5.8-focal swift build --static-swift-stdlib
```

will work – but it'll allow _release_ builds to work, which is the context in which the build failure is actually relevant:

```
docker run --rm -v "$PWD":/host -w /host swift:5.8-focal swift build -c release --static-swift-stdlib
```