### PR TITLE
Reintroduce withMainSerialExecutor

### DIFF
--- a/Sources/Dependencies/ConcurrencySupport/MainSerialExecutor.swift
+++ b/Sources/Dependencies/ConcurrencySupport/MainSerialExecutor.swift
@@ -16,15 +16,6 @@ import Foundation
 private typealias Orig = @convention(thin) (UnownedJob) -> Void
 private typealias Hook = @convention(thin) (UnownedJob, Orig) -> Void
 private var swift_task_enqueueGlobal_hook: UnsafeMutablePointer<Hook>? = {
-  var info = Dl_info()
-  guard
-    withUnsafePointer(to: TaskPriority.self, {
-      $0.withMemoryRebound(to: UnsafeRawPointer.self, capacity: 1) {
-        dladdr($0.pointee, &info)
-      }
-    }) != 0,
-    let handle = dlopen(info.dli_fname, RTLD_LAZY),
-    let symbol = dlsym(handle, "swift_task_enqueueGlobal_hook")
-  else { return nil }
-  return symbol.assumingMemoryBound(to: Hook.self)
+  dlsym(dlopen(nil, 0), "swift_task_enqueueGlobal_hook")?
+    .assumingMemoryBound(to: Hook.self)
 }()

--- a/Sources/Dependencies/ConcurrencySupport/MainSerialExecutor.swift
+++ b/Sources/Dependencies/ConcurrencySupport/MainSerialExecutor.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+@_spi(Concurrency) public func withMainSerialExecutor<T>(
+  @_implicitSelfCapture operation: () async throws -> T
+) async rethrows -> T {
+  guard let pointer = swift_task_enqueueGlobal_hook else { return try await operation() }
+  let hook = pointer.pointee
+  defer { pointer.pointee = hook }
+  pointer.pointee = { job, original in
+    MainActor.shared.enqueue(job)
+  }
+  return try await operation()
+}
+
+// here be dragons
+private typealias Orig = @convention(thin) (UnownedJob) -> Void
+private typealias Hook = @convention(thin) (UnownedJob, Orig) -> Void
+private var swift_task_enqueueGlobal_hook: UnsafeMutablePointer<Hook>? = {
+  var info = Dl_info()
+  guard
+    withUnsafePointer(to: TaskPriority.self, {
+      $0.withMemoryRebound(to: UnsafeRawPointer.self, capacity: 1) {
+        dladdr($0.pointee, &info)
+      }
+    }) != 0,
+    let handle = dlopen(info.dli_fname, RTLD_LAZY),
+    let symbol = dlsym(handle, "swift_task_enqueueGlobal_hook")
+  else { return nil }
+  return symbol.assumingMemoryBound(to: Hook.self)
+}()

--- a/Tests/DependenciesTests/MainSerialExecutorTests.swift
+++ b/Tests/DependenciesTests/MainSerialExecutorTests.swift
@@ -1,0 +1,29 @@
+@_spi(Concurrency) import Dependencies
+import XCTest
+
+final class MainSerialExecutorTests: XCTestCase {
+  func testSerializedExecution() async {
+    let xs = LockIsolated<[Int]>([])
+    await withMainSerialExecutor {
+      await withTaskGroup(of: Void.self) { group in
+        for x in 1...1000 {
+          group.addTask {
+            xs.withValue { $0.append(x) }
+          }
+        }
+      }
+    }
+    xs.withValue { XCTAssertEqual(Array(1...1000), $0) }
+  }
+
+  func testSerializedExecution_UnstructuredTasks() async {
+    await withMainSerialExecutor {
+      let xs = LockIsolated<[Int]>([])
+      for x in 1...1000 {
+        Task { xs.withValue { $0.append(x) } }
+      }
+      while xs.count < 1_000 { await Task.yield() }
+      xs.withValue { XCTAssertEqual(Array(1...1000), $0) }
+    }
+  }
+}


### PR DESCRIPTION
This PR reintroduces `withMainSerialExecutor` using `dlsym` rather than a C module, skirting around the issues highlighted in #83.

Diff between the old and new approaches: https://github.com/pointfreeco/swift-dependencies/compare/cd4edcf...4babbda