### PR TITLE
Update clock test values to be powered by live clocks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "f9acfa1a45f4483fe0f2c434a74e6f68f865d12d",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.1.0"),
-    .package(url: "https://github.com/pointfreeco/swift-clocks", from: "0.1.0"),
+    .package(url: "https://github.com/pointfreeco/swift-clocks", from: "0.3.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.8.0"),
   ],
   targets: [

--- a/Sources/Dependencies/DependencyValues/Clocks.swift
+++ b/Sources/Dependencies/DependencyValues/Clocks.swift
@@ -69,12 +69,10 @@
 
     private enum ContinuousClockKey: DependencyKey {
       static let liveValue: any Clock<Duration> = ContinuousClock()
-      static let testValue: any Clock<Duration> = UnimplementedClock(name: "ContinuousClock")
     }
 
     private enum SuspendingClockKey: DependencyKey {
       static let liveValue: any Clock<Duration> = SuspendingClock()
-      static let testValue: any Clock<Duration> = UnimplementedClock(name: "SuspendingClock")
     }
   }
 #endif

--- a/Sources/Dependencies/DependencyValues/Clocks.swift
+++ b/Sources/Dependencies/DependencyValues/Clocks.swift
@@ -69,10 +69,12 @@
 
     private enum ContinuousClockKey: DependencyKey {
       static let liveValue: any Clock<Duration> = ContinuousClock()
+      static let testValue: any Clock<Duration> = UnimplementedClock(.continuous)
     }
 
     private enum SuspendingClockKey: DependencyKey {
       static let liveValue: any Clock<Duration> = SuspendingClock()
+      static let testValue: any Clock<Duration> = UnimplementedClock(.suspending)
     }
   }
 #endif


### PR DESCRIPTION
Currently, the clock test values use an unimplemented clock that is powered by an "immediate" clock, but this can create a lot of noise when working with timers, where many many extra failures can occur quickly.

Instead, we should default to "live" clocks that report test failures to make the behavior closer to reality.