### PR TITLE
Rename `streamWithContinuation` to `makeStream`

### DIFF
--- a/Sources/Dependencies/ConcurrencySupport/AsyncStream.swift
+++ b/Sources/Dependencies/ConcurrencySupport/AsyncStream.swift
@@ -63,7 +63,7 @@ extension AsyncStream {
   #if swift(<5.9)
     /// Constructs and returns a stream along with its backing continuation.
     ///
-    /// A back-port of [SE-0388: Async Stream Factory][se-0388].
+    /// A back-port of [SE-0388: Convenience Async[Throwing]Stream.makeStream methods][se-0388].
     ///
     /// This is handy for immediately escaping the continuation from an async stream, which
     /// typically requires multiple steps:

--- a/Sources/Dependencies/ConcurrencySupport/AsyncStream.swift
+++ b/Sources/Dependencies/ConcurrencySupport/AsyncStream.swift
@@ -31,12 +31,11 @@ extension AsyncStream {
   /// }
   /// ```
   ///
-  /// While your tests can use `AsyncStream.streamWithContinuation` to spin up a controllable stream
-  /// for tests:
+  /// While your tests can use `AsyncStream.makeStream` to spin up a controllable stream for tests:
   ///
   /// ```swift
   /// func testScreenshots() {
-  ///   let screenshots = AsyncStream<Void>.streamWithContinuation()
+  ///   let screenshots = AsyncStream.makeStream(of: Void.self)
   ///
   ///   let model = withDependencies {
   ///     $0.screenshots = { screenshots.stream }
@@ -61,59 +60,65 @@ extension AsyncStream {
     }
   }
 
-  /// Constructs and returns a stream along with its backing continuation.
-  ///
-  /// This is handy for immediately escaping the continuation from an async stream, which typically
-  /// requires multiple steps:
-  ///
-  /// ```swift
-  /// var _continuation: AsyncStream<Int>.Continuation!
-  /// let stream = AsyncStream<Int> { continuation = $0 }
-  /// let continuation = _continuation!
-  ///
-  /// // vs.
-  ///
-  /// let (stream, continuation) = AsyncStream<Int>.streamWithContinuation()
-  /// ```
-  ///
-  /// This tool is usually used for tests where we need to supply an async sequence to a dependency
-  /// endpoint and get access to its continuation so that we can emulate the dependency emitting
-  /// data. For example, suppose you have a dependency exposing an async sequence for listening to
-  /// notifications. To test this you can use `streamWithContinuation`:
-  ///
-  /// ```swift
-  /// func testScreenshots() {
-  ///   let screenshots = AsyncStream<Void>.streamWithContinuation()
-  ///
-  ///   let model = withDependencies {
-  ///     $0.screenshots = { screenshots.stream }
-  ///   } operation: {
-  ///     FeatureModel()
-  ///   }
-  ///
-  ///   XCTAssertEqual(model.screenshotCount, 0)
-  ///   screenshots.continuation.yield()  // Simulate a screenshot being taken.
-  ///   XCTAssertEqual(model.screenshotCount, 1)
-  /// }
-  /// ```
-  ///
-  /// > Warning: ⚠️ `AsyncStream` does not support multiple subscribers, therefore you can only use
-  /// > this helper to test features that do not subscribe multiple times to the dependency
-  /// > endpoint.
-  ///
-  /// - Parameters:
-  ///   - elementType: The type of element the `AsyncStream` produces.
-  ///   - limit: A Continuation.BufferingPolicy value to set the stream’s buffering behavior. By
-  ///     default, the stream buffers an unlimited number of elements. You can also set the policy
-  ///     to buffer a specified number of oldest or newest elements.
-  /// - Returns: An `AsyncStream`.
-  public static func streamWithContinuation(
-    _ elementType: Element.Type = Element.self,
-    bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
-  ) -> (stream: Self, continuation: Continuation) {
-    var continuation: Continuation!
-    return (Self(elementType, bufferingPolicy: limit) { continuation = $0 }, continuation)
-  }
+  #if swift(<5.9)
+    /// Constructs and returns a stream along with its backing continuation.
+    ///
+    /// A back-port of [SE-0388: Async Stream Factory][se-0388].
+    ///
+    /// This is handy for immediately escaping the continuation from an async stream, which
+    /// typically requires multiple steps:
+    ///
+    /// ```swift
+    /// var _continuation: AsyncStream<Int>.Continuation!
+    /// let stream = AsyncStream<Int> { continuation = $0 }
+    /// let continuation = _continuation!
+    ///
+    /// // vs.
+    ///
+    /// let (stream, continuation) = AsyncStream.makeStream(of: Int.self)
+    /// ```
+    ///
+    /// This tool is usually used for tests where we need to supply an async sequence to a
+    /// dependency endpoint and get access to its continuation so that we can emulate the dependency
+    /// emitting data. For example, suppose you have a dependency exposing an async sequence for
+    /// listening to notifications. To test this you can use `makeStream`:
+    ///
+    /// ```swift
+    /// func testScreenshots() {
+    ///   let screenshots = AsyncStream.makeStream(of: Void.self)
+    ///
+    ///   let model = withDependencies {
+    ///     $0.screenshots = { screenshots.stream }
+    ///   } operation: {
+    ///     FeatureModel()
+    ///   }
+    ///
+    ///   XCTAssertEqual(model.screenshotCount, 0)
+    ///   screenshots.continuation.yield()  // Simulate a screenshot being taken.
+    ///   XCTAssertEqual(model.screenshotCount, 1)
+    /// }
+    /// ```
+    ///
+    /// > Warning: ⚠️ `AsyncStream` does not support multiple subscribers, therefore you can only
+    /// > use this helper to test features that do not subscribe multiple times to the dependency
+    /// > endpoint.
+    ///
+    /// [se-0388]: https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md
+    ///
+    /// - Parameters:
+    ///   - elementType: The type of element the `AsyncStream` produces.
+    ///   - limit: A Continuation.BufferingPolicy value to set the stream’s buffering behavior. By
+    ///     default, the stream buffers an unlimited number of elements. You can also set the policy
+    ///     to buffer a specified number of oldest or newest elements.
+    /// - Returns: An `AsyncStream`.
+    public static func makeStream(
+      of elementType: Element.Type = Element.self,
+      bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
+    ) -> (stream: Self, continuation: Continuation) {
+      var continuation: Continuation!
+      return (Self(elementType, bufferingPolicy: limit) { continuation = $0 }, continuation)
+    }
+  #endif
 
   /// An `AsyncStream` that never emits and never completes unless cancelled.
   public static var never: Self {

--- a/Sources/Dependencies/ConcurrencySupport/AsyncThrowingStream.swift
+++ b/Sources/Dependencies/ConcurrencySupport/AsyncThrowingStream.swift
@@ -13,59 +13,67 @@ extension AsyncThrowingStream where Failure == Error {
     }
   }
 
-  /// Constructs and returns a stream along with its backing continuation.
-  ///
-  /// This is handy for immediately escaping the continuation from an async stream, which typically
-  /// requires multiple steps:
-  ///
-  /// ```swift
-  /// var _continuation: AsyncThrowingStream<Int, Error>.Continuation!
-  /// let stream = AsyncThrowingStream<Int, Error> { continuation = $0 }
-  /// let continuation = _continuation!
-  ///
-  /// // vs.
-  ///
-  /// let (stream, continuation) = AsyncThrowingStream<Int, Error>.streamWithContinuation()
-  /// ```
-  ///
-  /// This tool is usually used for tests where we need to supply an async sequence to a dependency
-  /// endpoint and get access to its continuation so that we can emulate the dependency emitting
-  /// data. For example, suppose you have a dependency exposing an async sequence for listening to
-  /// notifications. To test this you can use `streamWithContinuation`:
-  ///
-  /// ```swift
-  /// func testScreenshots() {
-  ///   let screenshots = AsyncThrowingStream<Void>.streamWithContinuation()
-  ///
-  ///   let model = withDependencies {
-  ///     $0.screenshots = { screenshots.stream }
-  ///   } operation: {
-  ///     FeatureModel()
-  ///   }
-  ///
-  ///   XCTAssertEqual(model.screenshotCount, 0)
-  ///   screenshots.continuation.yield()  // Simulate a screenshot being taken.
-  ///   XCTAssertEqual(model.screenshotCount, 1)
-  /// }
-  /// ```
-  ///
-  /// > Warning: ⚠️ `AsyncStream` does not support multiple subscribers, therefore you can only use
-  /// > this helper to test features that do not subscribe multiple times to the dependency
-  /// > endpoint.
-  ///
-  /// - Parameters:
-  ///   - elementType: The type of element the `AsyncThrowingStream` produces.
-  ///   - limit: A Continuation.BufferingPolicy value to set the stream’s buffering behavior. By
-  ///     default, the stream buffers an unlimited number of elements. You can also set the policy
-  ///     to buffer a specified number of oldest or newest elements.
-  /// - Returns: An `AsyncThrowingStream`.
-  public static func streamWithContinuation(
-    _ elementType: Element.Type = Element.self,
-    bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
-  ) -> (stream: Self, continuation: Continuation) {
-    var continuation: Continuation!
-    return (Self(elementType, bufferingPolicy: limit) { continuation = $0 }, continuation)
-  }
+  #if swift(<5.9)
+    /// Constructs and returns a stream along with its backing continuation.
+    ///
+    /// A back-port of [SE-0388: Async Stream Factory][se-0388].
+    ///
+    /// This is handy for immediately escaping the continuation from an async stream, which
+    /// typically requires multiple steps:
+    ///
+    /// ```swift
+    /// var _continuation: AsyncThrowingStream<Int, Error>.Continuation!
+    /// let stream = AsyncThrowingStream<Int, Error> { continuation = $0 }
+    /// let continuation = _continuation!
+    ///
+    /// // vs.
+    ///
+    /// let (stream, continuation) = AsyncThrowingStream.makeStream(of: Int.self)
+    /// ```
+    ///
+    /// This tool is usually used for tests where we need to supply an async sequence to a
+    /// dependency endpoint and get access to its continuation so that we can emulate the dependency
+    /// emitting data. For example, suppose you have a dependency exposing an async sequence for
+    /// listening to notifications. To test this you can use `makeStream`:
+    ///
+    /// ```swift
+    /// func testScreenshots() {
+    ///   let screenshots = AsyncThrowingStream.makeStream(of: Void.self)
+    ///
+    ///   let model = withDependencies {
+    ///     $0.screenshots = { screenshots.stream }
+    ///   } operation: {
+    ///     FeatureModel()
+    ///   }
+    ///
+    ///   XCTAssertEqual(model.screenshotCount, 0)
+    ///   screenshots.continuation.yield()  // Simulate a screenshot being taken.
+    ///   XCTAssertEqual(model.screenshotCount, 1)
+    /// }
+    /// ```
+    ///
+    /// > Warning: ⚠️ `AsyncThrowingStream` does not support multiple subscribers, therefore you can
+    /// > only use this helper to test features that do not subscribe multiple times to the
+    /// > dependency endpoint.
+    ///
+    /// [se-0388]: https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md
+    ///
+    /// - Parameters:
+    ///   - elementType: The type of element the `AsyncThrowingStream` produces.
+    ///   - failureType: The type of failure the `AsyncThrowingStream` throws.
+    ///   - limit: A Continuation.BufferingPolicy value to set the stream’s buffering behavior. By
+    ///     default, the stream buffers an unlimited number of elements. You can also set the policy
+    ///     to buffer a specified number of oldest or newest elements.
+    /// - Returns: An `AsyncThrowingStream`.
+    public static func makeStream(
+      of elementType: Element.Type = Element.self,
+      throwing failureType: Failure.Type = Failure.self,
+      bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
+    ) -> (stream: Self, continuation: Continuation) {
+      var continuation: Continuation!
+      return (Self(elementType, bufferingPolicy: limit) { continuation = $0 }, continuation)
+    }
+  #endif
 
   /// An `AsyncThrowingStream` that never emits and never completes unless cancelled.
   public static var never: Self {

--- a/Sources/Dependencies/ConcurrencySupport/AsyncThrowingStream.swift
+++ b/Sources/Dependencies/ConcurrencySupport/AsyncThrowingStream.swift
@@ -16,7 +16,7 @@ extension AsyncThrowingStream where Failure == Error {
   #if swift(<5.9)
     /// Constructs and returns a stream along with its backing continuation.
     ///
-    /// A back-port of [SE-0388: Async Stream Factory][se-0388].
+    /// A back-port of [SE-0388: Convenience Async[Throwing]Stream.makeStream methods][se-0388].
     ///
     /// This is handy for immediately escaping the continuation from an async stream, which
     /// typically requires multiple steps:

--- a/Sources/Dependencies/Documentation.docc/Articles/ConcurrencySupport.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/ConcurrencySupport.md
@@ -53,7 +53,7 @@ The library comes with numerous helper APIs spread across the two Swift stream t
     be handy in tests when overriding a dependency endpoint that returns a stream:
 
     ```swift
-    let screenshots = AsyncStream<Void>.streamWithContinuation()
+    let screenshots = AsyncStream.makeStream(of: Void.self)
 
     let model = withDependencies {
       $0.screenshots = { screenshots.stream }

--- a/Sources/Dependencies/Internal/Deprecations.swift
+++ b/Sources/Dependencies/Internal/Deprecations.swift
@@ -12,7 +12,7 @@ extension AsyncStream {
 }
 
 extension AsyncThrowingStream where Failure == Error {
-  @available(*, deprecated, renamed: "makeStream(of:bufferingPolicy:)")
+  @available(*, deprecated, renamed: "makeStream(of:throwing:bufferingPolicy:)")
   public static func streamWithContinuation(
     _ elementType: Element.Type = Element.self,
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded

--- a/Sources/Dependencies/Internal/Deprecations.swift
+++ b/Sources/Dependencies/Internal/Deprecations.swift
@@ -1,3 +1,29 @@
+// MARK: - Deprecated after 0.4.2
+
+extension AsyncStream {
+  @available(*, deprecated, renamed: "makeStream(of:bufferingPolicy:)")
+  public static func streamWithContinuation(
+    _ elementType: Element.Type = Element.self,
+    bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
+  ) -> (stream: Self, continuation: Continuation) {
+    var continuation: Continuation!
+    return (Self(elementType, bufferingPolicy: limit) { continuation = $0 }, continuation)
+  }
+}
+
+extension AsyncThrowingStream where Failure == Error {
+  @available(*, deprecated, renamed: "makeStream(of:bufferingPolicy:)")
+  public static func streamWithContinuation(
+    _ elementType: Element.Type = Element.self,
+    bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded
+  ) -> (stream: Self, continuation: Continuation) {
+    var continuation: Continuation!
+    return (Self(elementType, bufferingPolicy: limit) { continuation = $0 }, continuation)
+  }
+}
+
+// MARK: -
+
 extension ActorIsolated {
   @available(
     *,


### PR DESCRIPTION
With [SE-388: Convenience Async[Throwing]Stream.makeStream methods][se-0388] officially in Swift 5.9, we can deprecate our version of this API and back-port the official API in the library.

[se-0388]: https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md