### PR TITLE
Bump up dependency ver 1.0.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ simple as adding it to your `Package.swift`:
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.1.0")
+  .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0")
 ]
 ```
 


### PR DESCRIPTION
Congratulations on the release of ver 1.0! 🎉 
I bumped up dependency to ver `1.0.0` in README accordingly.