### PR TITLE
Avoid watchOS test crash

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -386,12 +386,8 @@ private final class CachedValues: @unchecked Sendable {
     private final class TestObserver: NSObject {}
 
     extension DispatchQueue {
-      private static let key = DispatchSpecificKey<UInt8>()
-      private static let value: UInt8 = 0
-
       fileprivate static func mainSync<R>(execute block: @Sendable () -> R) -> R {
-        Self.main.setSpecific(key: Self.key, value: Self.value)
-        if getSpecific(key: Self.key) == Self.value {
+        if Thread.isMainThread {
           return block()
         } else {
           return Self.main.sync(execute: block)


### PR DESCRIPTION
We've been using `DispatchQueue`'s `setSpecific` and `getSpecific` to detect the main queue, but this doesn't seem to work in watchOS (or maybe I've been holding it wrong). I think in our case we really only care if we're on the main thread, so I'm hoping a `Thread.isMainThread` is enough.

If this fix is appropriate we should apply it to other repos that rely on this, as well, like SnapshotTesting.

Fixes #120