### PR TITLE
Add public method to clear dependency cache

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -371,7 +371,7 @@ private final class CachedValues: @unchecked Sendable {
               .takeUnretainedValue()
           else { return }
           let testCaseWillStartBlock: @convention(block) (AnyObject) -> Void = { _ in
-            DependencyValues._current.cachedValues.cached = [:]
+            DependencyValues._current.clearCache()
           }
           let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
           class_addMethod(
@@ -404,7 +404,7 @@ private final class CachedValues: @unchecked Sendable {
 
     private final class TestObserver: NSObject, XCTestObservation {
       func testCaseWillStart(_ testCase: XCTestCase) {
-        DependencyValues._current.cachedValues.cached = [:]
+        DependencyValues._current.clearCache()
       }
     }
   #endif

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -200,6 +200,11 @@ public struct DependencyValues: Sendable {
     return values
   }
 
+  /// Clears the dependency cache.
+  public func clearCache() {
+      cachedValues.cached = [:]
+  }
+
   func merging(_ other: Self) -> Self {
     var values = self
     values.storage.merge(other.storage, uniquingKeysWith: { $1 })

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -86,7 +86,7 @@ public struct DependencyValues: Sendable {
   #endif
   @TaskLocal static var currentDependency = CurrentDependency()
 
-  fileprivate var cachedValues = CachedValues()
+  private var cachedValues = CachedValues()
   private var storage: [ObjectIdentifier: AnySendable] = [:]
 
   /// Creates a dependency values instance.


### PR DESCRIPTION
We need a way to clear the dependency cache outside of an XCTest context.

Summary of changes:
1. Adds a public `DependencyValues.clearCache()` function which is an proxy for `cachedValues.cached = [:]`.
2. Converts the existing callsites over to the new function.
3. Changes `DependencyValues.cachedValues` from `fileprivate` to `private` given the new function.