### PR TITLE
Add community library link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ following projects all build on top of Dependencies:
 
   * [Dependencies Additions](https://github.com/tgrapperon/swift-dependencies-additions): A
     companion library that provides higher-level dependencies.
+  * [Dependencies Extras](https://github.com/arasan01/swift-dependencies-extras): Macros that make Swift Dependencies more useful
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ following projects all build on top of Dependencies:
 
   * [Dependencies Additions](https://github.com/tgrapperon/swift-dependencies-additions): A
     companion library that provides higher-level dependencies.
-  * [Dependencies Extras](https://github.com/arasan01/swift-dependencies-extras): Macros that make swift-dependencies more useful
+  * [Dependencies Protocol Extras](https://github.com/arasan01/swift-dependencies-extras): Library to make swift-dependencies even more useful when using Protocol
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ following projects all build on top of Dependencies:
 
   * [Dependencies Additions](https://github.com/tgrapperon/swift-dependencies-additions): A
     companion library that provides higher-level dependencies.
-  * [Dependencies Extras](https://github.com/arasan01/swift-dependencies-extras): Macros that make Swift Dependencies more useful
+  * [Dependencies Extras](https://github.com/arasan01/swift-dependencies-extras): Macros that make swift-dependencies more useful
 
 ## Alternatives
 


### PR DESCRIPTION
## What is the purpose of the PR?

I would like to add a link to the community library we have created.

## Why did this work occur?

I am developing with swift-dependencies as a central part of my product. In this process, there was a lot of protocol-oriented development. So I thought Swift Macros could automatically convert this to Struct-based and realize function-by-function processing changes. We believe this will be of great help to projects with similar challenges.

## Why create a separate library and then do a PR to add the link? Why not add this feature to this repository?

We believe this will help a great many people, but ideally as a pointfreeco library, this conversion is not even necessary. This is why we are creating it as a community library.

## Libraries to be linked in this PR

https://github.com/arasan01/swift-dependencies-extras