### PR TITLE
Fix fatalerror default

### DIFF
--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -164,3 +164,10 @@ public struct Unimplemented: Error {
     self.endpoint = endpoint
   }
 }
+
+struct Blah {
+  @DependencyEndpoint
+  public var foo: () -> String = { fatalError() }
+  @DependencyEndpoint
+  public var bar: () -> String = { fatalError("Goodbye") }
+}

--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -164,10 +164,3 @@ public struct Unimplemented: Error {
     self.endpoint = endpoint
   }
 }
-
-struct Blah {
-  @DependencyEndpoint
-  public var foo: () -> String = { fatalError() }
-  @DependencyEndpoint
-  public var bar: () -> String = { fatalError("Goodbye") }
-}

--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -22,8 +22,11 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
       return []
     }
     // NB: Ideally `@DependencyEndpoint` would handle this for us, but there are compiler crashes
-    if let initializer = binding.initializer {
-      try initializer.diagnose(node)
+    if 
+      let initializer = binding.initializer,
+      try initializer.diagnose(node, context: context).earlyOut
+    {
+      return []
     } else if functionType.effectSpecifiers?.throwsSpecifier == nil,
       !functionType.isVoid,
       !functionType.isOptional

--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -92,8 +92,6 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
               expression: expression.trimmed
             )
           )
-        } else {
-          context.diagnoseFatalErrorDefault(statement: statement)
         }
         closure.statements = closure.statements.with(\.[closure.statements.startIndex], statement)
       }

--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -88,6 +88,47 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
               expression: expression.trimmed
             )
           )
+        } else {
+          context.diagnose(
+            Diagnostic(
+              node: statement.item,
+              message: MacroExpansionWarningMessage(
+                """
+                Prefer to use a real default value rather than fatalError().
+
+                The default value can be anything and does not need to signify a real value. For \
+                example, if the endpoint returns a boolean, you can return false, or if it \
+                returns an array, you can return [].
+                """
+              ),
+              fixIt: FixIt(
+                message: MacroExpansionFixItMessage(
+                  """
+                  Silence this warning by wrapping fatalError() in a synchronously executed \
+                  closure, but we recommend against this.
+                  """
+                ),
+                changes: [
+                  .replace(
+                    oldNode: Syntax(statement),
+                    newNode: Syntax(
+                      FunctionCallExprSyntax(
+                        calledExpression: ClosureExprSyntax(
+                          statements: [
+                            statement.with(\.leadingTrivia, .space)
+                          ]
+                        ),
+                        leftParen: .leftParenToken(),
+                        arguments: [],
+                        rightParen: .rightParenToken()
+                      )
+                      .with(\.trailingTrivia, .space)
+                    )
+                  )
+                ]
+              )
+            )
+          )
         }
         closure.statements = closure.statements.with(\.[closure.statements.startIndex], statement)
       }

--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -21,8 +21,7 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
     else {
       return []
     }
-    if
-      let initializer = binding.initializer,
+    if let initializer = binding.initializer,
       try initializer.diagnose(node, context: context).earlyOut
     {
       return []
@@ -80,10 +79,12 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
       else {
         return []
       }
-      if !functionType.isVoid,
-        closure.statements.count == 1,
+      if closure.statements.count == 1,
         var statement = closure.statements.first,
-        let expression = statement.item.as(ExprSyntax.self)
+        let expression = statement.item.as(ExprSyntax.self),
+        !functionType.isVoid
+          || expression.as(FunctionCallExprSyntax.self)?.calledExpression.is(ClosureExprSyntax.self)
+            == true
       {
         if !statement.item.description.hasPrefix("fatalError(") {
           statement.item = CodeBlockItemSyntax.Item(

--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -81,12 +81,14 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
         var statement = closure.statements.first,
         let expression = statement.item.as(ExprSyntax.self)
       {
-        statement.item = CodeBlockItemSyntax.Item(
-          ReturnStmtSyntax(
-            returnKeyword: .keyword(.return, trailingTrivia: .space),
-            expression: expression.trimmed
+        if !statement.item.description.hasPrefix("fatalError(") {
+          statement.item = CodeBlockItemSyntax.Item(
+            ReturnStmtSyntax(
+              returnKeyword: .keyword(.return, trailingTrivia: .space),
+              expression: expression.trimmed
+            )
           )
-        )
+        }
         closure.statements = closure.statements.with(\.[closure.statements.startIndex], statement)
       }
       unimplementedDefault = closure

--- a/Sources/DependenciesMacrosPlugin/Support.swift
+++ b/Sources/DependenciesMacrosPlugin/Support.swift
@@ -108,7 +108,8 @@ extension InitializerClauseSyntax {
     
     guard
       closure.statements.count == 1,
-      let statement = closure.statements.first
+      let statement = closure.statements.first,
+      statement.item.description.hasPrefix("fatalError(")
     else {
       return DiagnosticAction(earlyOut: false)
     }

--- a/Sources/DependenciesMacrosPlugin/Support.swift
+++ b/Sources/DependenciesMacrosPlugin/Support.swift
@@ -118,20 +118,20 @@ extension InitializerClauseSyntax {
       Diagnostic(
         node: statement.item,
         message: MacroExpansionWarningMessage(
-                """
-                Prefer to use a real default value rather than fatalError().
-                
-                The default value can be anything and does not need to signify a real value. For \
-                example, if the endpoint returns a boolean, you can return false, or if it \
-                returns an array, you can return [].
-                """
+          """
+          Prefer returning a default value over 'fatalError()' to avoid crashes in previews and \
+          tests.
+
+          The default value can be anything and does not need to signify a real value. For \
+          example, if the endpoint returns a boolean, you can return 'false', or if it returns an \
+          array, you can return '[]'.
+          """
         ),
         fixIt: FixIt(
           message: MacroExpansionFixItMessage(
-                  """
-                  Silence this warning by wrapping fatalError() in a synchronously executed \
-                  closure, but we recommend against this.
-                  """
+            """
+            Wrap in a synchronously executed closure to silence this warning
+            """
           ),
           changes: [
             .replace(

--- a/Sources/DependenciesMacrosPlugin/Support.swift
+++ b/Sources/DependenciesMacrosPlugin/Support.swift
@@ -119,8 +119,8 @@ extension InitializerClauseSyntax {
         node: statement.item,
         message: MacroExpansionWarningMessage(
           """
-          Prefer returning a default value over 'fatalError()' to avoid crashes in previews and \
-          tests.
+          Prefer returning a default mock value over 'fatalError()' to avoid crashes in previews \
+          and tests.
 
           The default value can be anything and does not need to signify a real value. For \
           example, if the endpoint returns a boolean, you can return 'false', or if it returns an \

--- a/Sources/DependenciesMacrosPlugin/Support.swift
+++ b/Sources/DependenciesMacrosPlugin/Support.swift
@@ -70,15 +70,11 @@ extension FunctionTypeSyntax {
   }
 }
 
-struct DiagnoseResult {
-  let earlyOut: Bool
-}
-
 extension InitializerClauseSyntax {
   func diagnose(
     _ attribute: AttributeSyntax,
     context: some MacroExpansionContext
-  ) throws -> DiagnoseResult {
+  ) throws -> DiagnosticAction {
     guard let closure = self.value.as(ClosureExprSyntax.self)
     else {
       var diagnostics: [Diagnostic] = [
@@ -114,7 +110,7 @@ extension InitializerClauseSyntax {
       closure.statements.count == 1,
       let statement = closure.statements.first
     else {
-      return DiagnoseResult(earlyOut: false)
+      return DiagnosticAction(earlyOut: false)
     }
     
     context.diagnose(
@@ -158,8 +154,12 @@ extension InitializerClauseSyntax {
       )
     )
     
-    return DiagnoseResult(earlyOut: true)
+    return DiagnosticAction(earlyOut: true)
   }
+}
+
+struct DiagnosticAction {
+  let earlyOut: Bool
 }
 
 extension VariableDeclSyntax {
@@ -219,11 +219,5 @@ extension MacroExpansionContext {
 extension Array where Element == String {
   func qualified(_ module: String) -> Self {
     self.flatMap { [$0, "\(module).\($0)"] }
-  }
-}
-
-extension MacroExpansionContext {
-  func diagnoseFatalErrorDefault(statement: CodeBlockItemSyntax) {
-
   }
 }

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -741,5 +741,42 @@ final class DependencyClientMacroTests: BaseTestCase {
       """
     }
   }
-}
 
+  func testFatalError() {
+    assertMacro {
+      """
+      @DependencyClient
+      struct Blah {
+        public var foo: () -> String = { fatalError() }
+        public var bar: () -> String = { fatalError("Goodbye") }
+      }
+      """
+    } diagnostics: {
+      """
+      @DependencyClient
+      struct Blah {
+        public var foo: () -> String = { fatalError() }
+                                         ┬───────────
+                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
+                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+        public var bar: () -> String = { fatalError("Goodbye") }
+                                         ┬────────────────────
+                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
+                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+      }
+      """
+    } fixes: {
+      """
+      @DependencyClient
+      struct Blah {
+        public var foo: () -> String = { { fatalError() }() }
+        public var bar: () -> String = { { fatalError("Goodbye") }() }
+      }
+      """
+    }
+  }
+}

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -516,7 +516,6 @@ final class DependencyClientMacroTests: BaseTestCase {
     } expansion: {
       """
       struct Client: Sendable {
-        @DependencyEndpoint
         var endpoint: @Sendable () -> Int = { <#Int#> }
 
         init(
@@ -741,5 +740,60 @@ final class DependencyClientMacroTests: BaseTestCase {
       """
     }
   }
-}
 
+  func testFatalError() {
+    assertMacro {
+      """
+      @DependencyClient
+      struct Blah {
+        public var foo: () -> String = { fatalError() }
+        public var bar: () -> String = { fatalError("Goodbye") }
+      }
+      """
+    } diagnostics: {
+      """
+      @DependencyClient
+      struct Blah {
+        public var foo: () -> String = { fatalError() }
+                                         ┬───────────
+                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
+                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+        public var bar: () -> String = { fatalError("Goodbye") }
+                                         ┬────────────────────
+                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
+                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+      }
+      """
+    } fixes: {
+      """
+      @DependencyClient
+      struct Blah {
+        public var foo: () -> String = { { fatalError() }() }
+        public var bar: () -> String = { { fatalError("Goodbye") }() }
+      }
+      """
+    } expansion: {
+      """
+      struct Blah {
+        public var foo: () -> String = { { fatalError() }() }
+        public var bar: () -> String = { { fatalError("Goodbye") }() }
+
+        public init(
+          foo: @escaping () -> String,
+          bar: @escaping () -> String
+        ) {
+          self.foo = foo
+          self.bar = bar
+        }
+
+        public init() {
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -513,22 +513,6 @@ final class DependencyClientMacroTests: BaseTestCase {
         var endpoint: @Sendable () -> Int = { <#Int#> }
       }
       """
-    } expansion: {
-      """
-      struct Client: Sendable {
-        @DependencyEndpoint
-        var endpoint: @Sendable () -> Int = { <#Int#> }
-
-        init(
-          endpoint: @Sendable @escaping () -> Int
-        ) {
-          self.endpoint = endpoint
-        }
-
-        init() {
-        }
-      }
-      """
     }
   }
 

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -513,6 +513,22 @@ final class DependencyClientMacroTests: BaseTestCase {
         var endpoint: @Sendable () -> Int = { <#Int#> }
       }
       """
+    } expansion: {
+      """
+      struct Client: Sendable {
+        @DependencyEndpoint
+        var endpoint: @Sendable () -> Int = { <#Int#> }
+
+        init(
+          endpoint: @Sendable @escaping () -> Int
+        ) {
+          self.endpoint = endpoint
+        }
+
+        init() {
+        }
+      }
+      """
     }
   }
 
@@ -725,42 +741,5 @@ final class DependencyClientMacroTests: BaseTestCase {
       """
     }
   }
-
-  func testFatalError() {
-    assertMacro {
-      """
-      @DependencyClient
-      struct Blah {
-        public var foo: () -> String = { fatalError() }
-        public var bar: () -> String = { fatalError("Goodbye") }
-      }
-      """
-    } diagnostics: {
-      """
-      @DependencyClient
-      struct Blah {
-        public var foo: () -> String = { fatalError() }
-                                         ┬───────────
-                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
-
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-        public var bar: () -> String = { fatalError("Goodbye") }
-                                         ┬────────────────────
-                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
-
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-      }
-      """
-    } fixes: {
-      """
-      @DependencyClient
-      struct Blah {
-        public var foo: () -> String = { { fatalError() }() }
-        public var bar: () -> String = { { fatalError("Goodbye") }() }
-      }
-      """
-    }
-  }
 }
+

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -741,13 +741,13 @@ final class DependencyClientMacroTests: BaseTestCase {
       struct Blah {
         public var foo: () -> String = { fatalError() }
                                          ┬───────────
-                                         ╰─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
+                                         ╰─ ⚠️ Prefer returning a default mock value over 'fatalError()' to avoid crashes in previews and tests.
 
       The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
                                             ✏️ Wrap in a synchronously executed closure to silence this warning
         public var bar: () -> String = { fatalError("Goodbye") }
                                          ┬────────────────────
-                                         ╰─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
+                                         ╰─ ⚠️ Prefer returning a default mock value over 'fatalError()' to avoid crashes in previews and tests.
 
       The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
                                             ✏️ Wrap in a synchronously executed closure to silence this warning

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -741,16 +741,16 @@ final class DependencyClientMacroTests: BaseTestCase {
       struct Blah {
         public var foo: () -> String = { fatalError() }
                                          ┬───────────
-                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+                                         ╰─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
+                                            ✏️ Wrap in a synchronously executed closure to silence this warning
         public var bar: () -> String = { fatalError("Goodbye") }
                                          ┬────────────────────
-                                         ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+                                         ╰─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                                            ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
+                                            ✏️ Wrap in a synchronously executed closure to silence this warning
       }
       """
     } fixes: {

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -513,21 +513,6 @@ final class DependencyClientMacroTests: BaseTestCase {
         var endpoint: @Sendable () -> Int = { <#Int#> }
       }
       """
-    } expansion: {
-      """
-      struct Client: Sendable {
-        var endpoint: @Sendable () -> Int = { <#Int#> }
-
-        init(
-          endpoint: @Sendable @escaping () -> Int
-        ) {
-          self.endpoint = endpoint
-        }
-
-        init() {
-        }
-      }
-      """
     }
   }
 
@@ -774,24 +759,6 @@ final class DependencyClientMacroTests: BaseTestCase {
       struct Blah {
         public var foo: () -> String = { { fatalError() }() }
         public var bar: () -> String = { { fatalError("Goodbye") }() }
-      }
-      """
-    } expansion: {
-      """
-      struct Blah {
-        public var foo: () -> String = { { fatalError() }() }
-        public var bar: () -> String = { { fatalError("Goodbye") }() }
-
-        public init(
-          foo: @escaping () -> String,
-          bar: @escaping () -> String
-        ) {
-          self.foo = foo
-          self.bar = bar
-        }
-
-        public init() {
-        }
       }
       """
     }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class DependencyEndpointMacroTests: BaseTestCase {
   override func invokeTest() {
     withMacroTesting(
-      //isRecording: true,
+      // isRecording: true,
       macros: [DependencyEndpointMacro.self]
     ) {
       super.invokeTest()
@@ -51,10 +51,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         @DependencyEndpoint
         var endpoint: () -> Bool = { _ in false }
       }
-      """
-    } diagnostics: {
-      """
-
       """
     } expansion: {
       """
@@ -729,10 +725,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
       }
       """
-    } diagnostics: {
-      """
-
-      """
     } expansion: {
       """
       struct Blah {
@@ -774,154 +766,34 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       }
     }
     """
-    } diagnostics: {
-      """
-
-      """
     } expansion: {
-      """
-      struct Blah {
-        public var doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
-          "Hello, world"
-        } {
-          @storageRestrictions(initializes: _doAThing)
-          init(initialValue) {
-            _doAThing = initialValue
-          }
-          get {
-            _doAThing
-          }
-          set {
-            _doAThing = newValue
-          }
+    """
+    struct Blah {
+      public var doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
+        "Hello, world"
+      } {
+        @storageRestrictions(initializes: _doAThing)
+        init(initialValue) {
+          _doAThing = initialValue
         }
-
-        public func doAThing(a p0: inout Int, b p1: Int, c p2: inout Bool) -> String {
-          self.doAThing(&p0, p1, &p2)
+        get {
+          _doAThing
         }
-
-        private var _doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
-          XCTestDynamicOverlay.XCTFail("Unimplemented: 'doAThing'")
-          return "Hello, world"
-          }
+        set {
+          _doAThing = newValue
+        }
       }
-      """
+
+      public func doAThing(a p0: inout Int, b p1: Int, c p2: inout Bool) -> String {
+        self.doAThing(&p0, p1, &p2)
+      }
+
+      private var _doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
+        XCTestDynamicOverlay.XCTFail("Unimplemented: 'doAThing'")
+        return "Hello, world"
+        }
     }
-  }
-
-  func testFatalError() {
-    assertMacro {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var foo: () -> String = { fatalError() }
-        @DependencyEndpoint
-        public var bar: () -> String = { fatalError("Goodbye") }
-      }
-      """
-    } diagnostics: {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var foo: () -> String = { fatalError() }
-                            ┬            ────────────
-                            ├─ ⚠️ Prefer to use a real default value rather than fatalError().
-
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                            │  ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.  │                       ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
-
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                               ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-        @DependencyEndpoint
-        public var bar: () -> String = { fatalError("Goodbye") }
-      }
-      """
-    }fixes: {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var foo: () -> String = { fatalError() }
-        @DependencyEndpoint
-        public var bar: () -> String = { fatalError("Goodbye") }
-      }
-      """
-    }expansion: {
-      """
-      struct Blah {
-        public var foo: () -> String = { fatalError() }
-
-        private var _foo: () -> String = {
-          XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
-          fatalError()
-        }
-        public var bar: () -> String = { fatalError("Goodbye") }
-
-        private var _bar: () -> String = {
-          XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
-          fatalError("Goodbye")
-        }
-      }
-      """
-    }
-  }
-
-  func testFatalError_SilenceWarning() {
-    assertMacro {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var foo: () -> String = { { fatalError() }() }
-        @DependencyEndpoint
-        public var bar: () -> String = { { fatalError("Goodbye") }() }
-      }
-      """
-    } diagnostics: {
-      """
-
-      """
-    } expansion: {
-      """
-      struct Blah {
-        public var foo: () -> String = { { fatalError() }() } {
-          @storageRestrictions(initializes: _foo)
-          init(initialValue) {
-            _foo = initialValue
-          }
-          get {
-            _foo
-          }
-          set {
-            _foo = newValue
-          }
-        }
-
-        private var _foo: () -> String = {
-          XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
-          return {
-            fatalError()
-          }()
-        }
-        public var bar: () -> String = { { fatalError("Goodbye") }() } {
-          @storageRestrictions(initializes: _bar)
-          init(initialValue) {
-            _bar = initialValue
-          }
-          get {
-            _bar
-          }
-          set {
-            _bar = newValue
-          }
-        }
-
-        private var _bar: () -> String = {
-          XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
-          return {
-            fatalError("Goodbye")
-          }()
-        }
-      }
-      """
+    """
     }
   }
 

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -145,7 +145,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
                ✏️ Insert '= { _, _, _ in <#Bool#> }'
       }
       """
-    }fixes: {
+    } fixes: {
       """
       struct Client {
         @DependencyEndpoint
@@ -894,7 +894,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
       struct Blah {
         @DependencyEndpoint
-        public var foo: () -> String = { { fatalError() }() }
+        public var foo: () -> Void = { { fatalError() }() }
         @DependencyEndpoint
         public var bar: () -> String = { { fatalError("Goodbye") }() }
       }
@@ -902,7 +902,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       """
       struct Blah {
-        public var foo: () -> String = { { fatalError() }() } {
+        public var foo: () -> Void = { { fatalError() }() } {
           @storageRestrictions(initializes: _foo)
           init(initialValue) {
             _foo = initialValue
@@ -915,7 +915,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
           }
         }
 
-        private var _foo: () -> String = {
+        private var _foo: () -> Void = {
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
           return {
             fatalError()

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -849,13 +849,13 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         @DependencyEndpoint
         public var foo: () -> String = { fatalError() }
                             ┬            ────────────
-                            ├─ ⚠️ Prefer to use a real default value rather than fatalError().
+                            ├─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                            │  ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.  │                       ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
+                            │  ✏️ Wrap in a synchronously executed closure to silence this warning  │                       ╰─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                               ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
+                               ✏️ Wrap in a synchronously executed closure to silence this warning
         @DependencyEndpoint
         public var bar: () -> String = { fatalError("Goodbye") }
       }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -56,13 +56,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
 
       """
-    }fixes: {
-      """
-      struct Client {
-        @DependencyEndpoint
-        var endpoint: () -> Bool = { _ in false }
-      }
-      """
     } expansion: {
       """
       struct Client {
@@ -740,15 +733,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
 
       """
-    }fixes: {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var doAThing: (_ value: Int) -> String = { _ in
-          "Hello, world"
-        }
-      }
-      """
     } expansion: {
       """
       struct Blah {
@@ -793,15 +777,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } diagnostics: {
       """
 
-      """
-    }fixes: {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
-          "Hello, world"
-        }
-      }
       """
     } expansion: {
       """
@@ -903,15 +878,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } diagnostics: {
       """
 
-      """
-    }fixes: {
-      """
-      struct Blah {
-        @DependencyEndpoint
-        public var foo: () -> String = { { fatalError() }() }
-        @DependencyEndpoint
-        public var bar: () -> String = { { fatalError("Goodbye") }() }
-      }
       """
     } expansion: {
       """

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -805,11 +805,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         public var foo: () -> String = { fatalError() }
         @DependencyEndpoint
         public var bar: () -> String = { fatalError("Goodbye") }
-        @DependencyEndpoint
-        public var baz: () -> String = {
-          print("Hello")
-          fatalError("Goodbye")
-        }
       }
       """
     } expansion: {
@@ -849,27 +844,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
           fatalError("Goodbye")
         }
-        public var baz: () -> String = {
-          print("Hello")
-          fatalError("Goodbye")
-        } {
-          @storageRestrictions(initializes: _baz)
-          init(initialValue) {
-            _baz = initialValue
-          }
-          get {
-            _baz
-          }
-          set {
-            _baz = newValue
-          }
-        }
-
-        private var _baz: () -> String = {
-          XCTestDynamicOverlay.XCTFail("Unimplemented: 'baz'")
-          print("Hello")
-          fatalError("Goodbye")
-          }
       }
       """
     }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -796,4 +796,82 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     """
     }
   }
+
+  func testFatalError() {
+    assertMacro {
+      """
+      struct Blah {
+        @DependencyEndpoint
+        public var foo: () -> String = { fatalError() }
+        @DependencyEndpoint
+        public var bar: () -> String = { fatalError("Goodbye") }
+        @DependencyEndpoint
+        public var baz: () -> String = {
+          print("Hello")
+          fatalError("Goodbye")
+        }
+      }
+      """
+    } expansion: {
+      """
+      struct Blah {
+        public var foo: () -> String = { fatalError() } {
+          @storageRestrictions(initializes: _foo)
+          init(initialValue) {
+            _foo = initialValue
+          }
+          get {
+            _foo
+          }
+          set {
+            _foo = newValue
+          }
+        }
+
+        private var _foo: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
+          fatalError()
+        }
+        public var bar: () -> String = { fatalError("Goodbye") } {
+          @storageRestrictions(initializes: _bar)
+          init(initialValue) {
+            _bar = initialValue
+          }
+          get {
+            _bar
+          }
+          set {
+            _bar = newValue
+          }
+        }
+
+        private var _bar: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
+          fatalError("Goodbye")
+        }
+        public var baz: () -> String = {
+          print("Hello")
+          fatalError("Goodbye")
+        } {
+          @storageRestrictions(initializes: _baz)
+          init(initialValue) {
+            _baz = initialValue
+          }
+          get {
+            _baz
+          }
+          set {
+            _baz = newValue
+          }
+        }
+
+        private var _baz: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'baz'")
+          print("Hello")
+          fatalError("Goodbye")
+          }
+      }
+      """
+    }
+  }
 }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -832,4 +832,116 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
     }
   }
+
+  func testFatalError() {
+    assertMacro {
+      """
+      struct Blah {
+        @DependencyEndpoint
+        public var foo: () -> String = { fatalError() }
+        @DependencyEndpoint
+        public var bar: () -> String = { fatalError("Goodbye") }
+      }
+      """
+    } diagnostics: {
+      """
+      struct Blah {
+        @DependencyEndpoint
+        public var foo: () -> String = { fatalError() }
+                            ┬            ────────────
+                            ├─ ⚠️ Prefer to use a real default value rather than fatalError().
+
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
+                            │  ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.  │                       ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
+
+      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
+                               ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
+        @DependencyEndpoint
+        public var bar: () -> String = { fatalError("Goodbye") }
+      }
+      """
+    } fixes: {
+      """
+      struct Blah {
+        @DependencyEndpoint
+        public var foo: () -> String = { fatalError() }
+        @DependencyEndpoint
+        public var bar: () -> String = { fatalError("Goodbye") }
+      }
+      """
+    } expansion: {
+      """
+      struct Blah {
+        public var foo: () -> String = { fatalError() }
+
+        private var _foo: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
+          fatalError()
+        }
+        public var bar: () -> String = { fatalError("Goodbye") }
+
+        private var _bar: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
+          fatalError("Goodbye")
+        }
+      }
+      """
+    }
+  }
+
+  func testFatalError_SilenceWarning() {
+    assertMacro {
+      """
+      struct Blah {
+        @DependencyEndpoint
+        public var foo: () -> String = { { fatalError() }() }
+        @DependencyEndpoint
+        public var bar: () -> String = { { fatalError("Goodbye") }() }
+      }
+      """
+    } expansion: {
+      """
+      struct Blah {
+        public var foo: () -> String = { { fatalError() }() } {
+          @storageRestrictions(initializes: _foo)
+          init(initialValue) {
+            _foo = initialValue
+          }
+          get {
+            _foo
+          }
+          set {
+            _foo = newValue
+          }
+        }
+
+        private var _foo: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
+          return {
+            fatalError()
+          }()
+        }
+        public var bar: () -> String = { { fatalError("Goodbye") }() } {
+          @storageRestrictions(initializes: _bar)
+          init(initialValue) {
+            _bar = initialValue
+          }
+          get {
+            _bar
+          }
+          set {
+            _bar = newValue
+          }
+        }
+
+        private var _bar: () -> String = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
+          return {
+            fatalError("Goodbye")
+          }()
+        }
+      }
+      """
+    }
+  }
 }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -54,17 +54,9 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
     } diagnostics: {
       """
-      struct Client {
-        @DependencyEndpoint
-        var endpoint: () -> Bool = { _ in false }
-                           ┬              ─────
-                           ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                              ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-      }
       """
-    } fixes: {
+    }fixes: {
       """
       struct Client {
         @DependencyEndpoint
@@ -74,7 +66,18 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       """
       struct Client {
-        var endpoint: () -> Bool = { _ in false }
+        var endpoint: () -> Bool = { _ in false } {
+          @storageRestrictions(initializes: _endpoint)
+          init(initialValue) {
+            _endpoint = initialValue
+          }
+          get {
+            _endpoint
+          }
+          set {
+            _endpoint = newValue
+          }
+        }
 
         private var _endpoint: () -> Bool = { _ in
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'endpoint'")
@@ -113,7 +116,18 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       """
       struct Client {
-        var endpoint: () -> Bool = { <#Bool#> }
+        var endpoint: () -> Bool = { <#Bool#> } {
+          @storageRestrictions(initializes: _endpoint)
+          init(initialValue) {
+            _endpoint = initialValue
+          }
+          get {
+            _endpoint
+          }
+          set {
+            _endpoint = newValue
+          }
+        }
 
         private var _endpoint: () -> Bool = {
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'endpoint'")
@@ -152,7 +166,18 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       """
       struct Client {
-        var endpoint: (Int, Bool, String) -> Bool = { _, _, _ in <#Bool#> }
+        var endpoint: (Int, Bool, String) -> Bool = { _, _, _ in <#Bool#> } {
+          @storageRestrictions(initializes: _endpoint)
+          init(initialValue) {
+            _endpoint = initialValue
+          }
+          get {
+            _endpoint
+          }
+          set {
+            _endpoint = newValue
+          }
+        }
 
         private var _endpoint: (Int, Bool, String) -> Bool = { _, _, _ in
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'endpoint'")
@@ -713,18 +738,9 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
     } diagnostics: {
       """
-      struct Blah {
-        @DependencyEndpoint
-        public var doAThing: (_ value: Int) -> String = { _ in
-                                                      ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                                                         ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-          "Hello, world"
-        }
-      }
       """
-    } fixes: {
+    }fixes: {
       """
       struct Blah {
         @DependencyEndpoint
@@ -738,6 +754,17 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       struct Blah {
         public var doAThing: (_ value: Int) -> String = { _ in
           "Hello, world"
+        } {
+          @storageRestrictions(initializes: _doAThing)
+          init(initialValue) {
+            _doAThing = initialValue
+          }
+          get {
+            _doAThing
+          }
+          set {
+            _doAThing = newValue
+          }
         }
 
         public func doAThing(value p0: Int) -> String {
@@ -765,18 +792,9 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     """
     } diagnostics: {
       """
-      struct Blah {
-        @DependencyEndpoint
-        public var doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
-                                                                                   ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                                                                                      ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-          "Hello, world"
-        }
-      }
       """
-    } fixes: {
+    }fixes: {
       """
       struct Blah {
         @DependencyEndpoint
@@ -790,6 +808,17 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       struct Blah {
         public var doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
           "Hello, world"
+        } {
+          @storageRestrictions(initializes: _doAThing)
+          init(initialValue) {
+            _doAThing = initialValue
+          }
+          get {
+            _doAThing
+          }
+          set {
+            _doAThing = newValue
+          }
         }
 
         public func doAThing(a p0: inout Int, b p1: Int, c p2: inout Bool) -> String {
@@ -873,22 +902,9 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
     } diagnostics: {
       """
-      struct Blah {
-        @DependencyEndpoint
-        public var foo: () -> String = { { fatalError() }() }
-                            ┬            ──────────────────
-                            ├─ ⚠️ Prefer to use a real default value rather than fatalError().
 
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                            │  ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.  │                       ╰─ ⚠️ Prefer to use a real default value rather than fatalError().
-
-      The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return false, or if it returns an array, you can return [].
-                               ✏️ Silence this warning by wrapping fatalError() in a synchronously executed closure, but we recommend against this.
-        @DependencyEndpoint
-        public var bar: () -> String = { { fatalError("Goodbye") }() }
-      }
       """
-    } fixes: {
+    }fixes: {
       """
       struct Blah {
         @DependencyEndpoint
@@ -900,7 +916,18 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       """
       struct Blah {
-        public var foo: () -> String = { { fatalError() }() }
+        public var foo: () -> String = { { fatalError() }() } {
+          @storageRestrictions(initializes: _foo)
+          init(initialValue) {
+            _foo = initialValue
+          }
+          get {
+            _foo
+          }
+          set {
+            _foo = newValue
+          }
+        }
 
         private var _foo: () -> String = {
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
@@ -908,7 +935,18 @@ final class DependencyEndpointMacroTests: BaseTestCase {
             fatalError()
           }()
         }
-        public var bar: () -> String = { { fatalError("Goodbye") }() }
+        public var bar: () -> String = { { fatalError("Goodbye") }() } {
+          @storageRestrictions(initializes: _bar)
+          init(initialValue) {
+            _bar = initialValue
+          }
+          get {
+            _bar
+          }
+          set {
+            _bar = newValue
+          }
+        }
 
         private var _bar: () -> String = {
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -849,10 +849,10 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         @DependencyEndpoint
         public var foo: () -> String = { fatalError() }
                             ┬            ────────────
-                            ├─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
+                            ├─ ⚠️ Prefer returning a default mock value over 'fatalError()' to avoid crashes in previews and tests.
 
       The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
-                            │  ✏️ Wrap in a synchronously executed closure to silence this warning  │                       ╰─ ⚠️ Prefer returning a default value over 'fatalError()' to avoid crashes in previews and tests.
+                            │  ✏️ Wrap in a synchronously executed closure to silence this warning  │                       ╰─ ⚠️ Prefer returning a default mock value over 'fatalError()' to avoid crashes in previews and tests.
 
       The default value can be anything and does not need to signify a real value. For example, if the endpoint returns a boolean, you can return 'false', or if it returns an array, you can return '[]'.
                                ✏️ Wrap in a synchronously executed closure to silence this warning


### PR DESCRIPTION
Fixes #148.

We don't recommend people use `fatalError`'s in their defaults, but we might as well generate valid Swift code if someone has a good reason to.