### PR TITLE
Support `@autoclosure` within arguments at `@DependencyEndpoint`

### DIFF
--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -796,4 +796,40 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     """
     }
   }
+
+  func testAutoclosure() {
+    assertMacro {
+      """
+      struct Foo {
+        @DependencyEndpoint
+        var bar: (_ a: @autoclosure () -> Int, _ b: () -> Int, _ c: @autoclosure () -> Int) -> Void
+      }
+      """
+    } expansion: {
+      """
+      struct Foo {
+        var bar: (_ a: @autoclosure () -> Int, _ b: () -> Int, _ c: @autoclosure () -> Int) -> Void {
+          @storageRestrictions(initializes: _bar)
+          init(initialValue) {
+            _bar = initialValue
+          }
+          get {
+            _bar
+          }
+          set {
+            _bar = newValue
+          }
+        }
+
+        func bar(a p0: @autoclosure () -> Int, b p1: () -> Int, c p2: @autoclosure () -> Int) -> Void {
+          self.bar(p0(), p1, p2())
+        }
+
+        private var _bar: (_ a: @autoclosure () -> Int, _ b: () -> Int, _ c: @autoclosure () -> Int) -> Void = { _, _, _ in
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'bar'")
+        }
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
Resolve #155 

## Cause
```swift
struct Foo {
  @DependencyEndpoint
  var bar: (_ a: Int) -> Void
}
```

In general, the code as shown can typically be transformed into the following without any issues. This is because the type of `a` that `func bar` receives matches the type of the argument `a` passed to `var bar`.

```swift
func bar(a p0: Int) -> Void {
  self.bar(p0)
}
```

This also applies to simple closures.

```swift
struct Foo {
  @DependencyEndpoint
  var bar: (_ a: () -> Int) -> Void
}

func bar(a p0: () -> Int) -> Void {
  self.bar(p0)
}
```

However, when considering closures marked with `@autoclosure`, upon closer examination of @autoclosure behavior, the type of `a` that `func bar` receives might not match the type of the argument `a` passed to `var bar`.

```swift
struct Foo {
  @DependencyEndpoint
  var bar: (_ a: () @autoclosure -> Int) -> Void
}

func bar(a p0: @autoclosure () -> Int) -> Void {
  self.bar(p0) // Error occurs: 'Add () to forward @autoclosure parameter'
}
```

## Solution
Simply adding `()` should resolve this bug.

```swift
struct Foo {
  @DependencyEndpoint
  var bar: (_ a: () @autoclosure -> Int) -> Void
}

func bar(a p0: @autoclosure () -> Int) -> Void {
  self.bar(p0()) // No Error occurs
}
```

## Concern
I might be overly concerned, but I feel there's a slight difference between directly invoking `var bar` and indirectly through `func bar`. When directly calling `var bar`, it receives `() -> String`. However, when calling `var bar` indirectly through `func bar`, it receives `() -> (() -> String)()`. I don't expect this difference to cause any change in behavior, but if there might be an issue, I'd appreciate some advice!