### PR TITLE
DependencyClient/Endpoint accessor fixes

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -95,8 +95,15 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
       if property.bindingSpecifier.tokenKind == .keyword(.let), binding.initializer != nil {
         continue
       }
-      if let accessors = binding.accessorBlock?.accessors, case .getter = accessors {
-        continue
+      if let accessors = binding.accessorBlock?.accessors {
+        switch accessors {
+        case .getter:
+          continue
+        case let .accessors(accessors):
+          if accessors.contains(where: { $0.accessorSpecifier.tokenKind == .keyword(.get) }) {
+            continue
+          }
+        }
       }
 
       if propertyAccess == .private, binding.initializer != nil { continue }
@@ -162,6 +169,7 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
         )
       }
       if isEndpoint {
+        binding.accessorBlock = nil
         binding.initializer = nil
       } else if binding.initializer == nil, type.is(OptionalTypeSyntax.self) {
         binding.typeAnnotation?.trailingTrivia = .space

--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -14,6 +14,7 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
   ) throws -> [AttributeSyntax] {
     guard
       let property = member.as(VariableDeclSyntax.self),
+      property.bindingSpecifier.tokenKind != .keyword(.let),
       property.isClosure,
       let binding = property.bindings.first,
       let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.trimmed,
@@ -85,7 +86,8 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
     var accesses: Set<Access> = Access(modifiers: declaration.modifiers).map { [$0] } ?? []
     for member in declaration.memberBlock.members {
       guard var property = member.decl.as(VariableDeclSyntax.self) else { continue }
-      let isEndpoint = property.hasDependencyEndpointMacroAttached || property.isClosure
+      let isEndpoint = property.hasDependencyEndpointMacroAttached
+        || property.bindingSpecifier.tokenKind != .keyword(.let) && property.isClosure
       let propertyAccess = Access(modifiers: property.modifiers)
       guard
         var binding = property.bindings.first,

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -72,6 +72,40 @@ final class DependencyClientMacroTests: BaseTestCase {
     }
   }
 
+  func testLetBinding() {
+    assertMacro {
+      """
+      @DependencyClient
+      struct Client {
+        var endpoint: () -> Void
+        let config: () -> Void
+      }
+      """
+    } expansion: {
+      """
+      struct Client {
+        @DependencyEndpoint
+        var endpoint: () -> Void
+        let config: () -> Void
+
+        init(
+          endpoint: @escaping () -> Void,
+          config: @escaping () -> Void
+        ) {
+          self.endpoint = endpoint
+          self.config = config
+        }
+
+        init(
+          config: @escaping () -> Void
+        ) {
+          self.config = config
+        }
+      }
+      """
+    }
+  }
+
   func testBooleanLiteral() {
     assertMacro {
       """

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -452,6 +452,80 @@ final class DependencyClientMacroTests: BaseTestCase {
     }
   }
 
+  func testComputedPropertyGet() {
+    assertMacro {
+      """
+      @DependencyClient
+      struct Client: Sendable {
+        var endpoint: @Sendable () -> Void
+
+        var name: String {
+          get {
+            "Blob"
+          }
+        }
+      }
+      """
+    } expansion: {
+      """
+      struct Client: Sendable {
+        @DependencyEndpoint
+        var endpoint: @Sendable () -> Void
+
+        var name: String {
+          get {
+            "Blob"
+          }
+        }
+
+        init(
+          endpoint: @Sendable @escaping () -> Void
+        ) {
+          self.endpoint = endpoint
+        }
+
+        init() {
+        }
+      }
+      """
+    }
+  }
+
+  func testComputedPropertyWillSet() {
+    assertMacro {
+      """
+      @DependencyClient
+      struct Client: Sendable {
+        var endpoint: @Sendable () throws -> Void {
+          willSet {
+            print("!")
+          }
+        }
+      }
+      """
+    } expansion: {
+      """
+      struct Client: Sendable {
+        @DependencyEndpoint
+        var endpoint: @Sendable () throws -> Void {
+          willSet {
+            print("!")
+          }
+        }
+
+        init(
+          endpoint: @Sendable @escaping () throws -> Void
+        ) {
+          self.endpoint = endpoint
+        }
+
+        init() {
+        }
+      }
+      """
+    }
+  }
+
   func testLet_WithDefault() {
     assertMacro {
       """
@@ -587,7 +661,7 @@ final class DependencyClientMacroTests: BaseTestCase {
           try self.fetch(p0)
         }
 
-        private var _fetch: (_ id: Int) throws -> String = { _ in
+        @available(iOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(macOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(tvOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(watchOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") private var _fetch: (_ id: Int) throws -> String = { _ in
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'fetch'")
           throw DependenciesMacros.Unimplemented("fetch")
         }
@@ -635,7 +709,7 @@ final class DependencyClientMacroTests: BaseTestCase {
           try self.fetch(p0)
         }
 
-        private var _fetch: (_ id: Int) throws -> String = { _ in
+        @available(iOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(macOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(tvOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(watchOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") private var _fetch: (_ id: Int) throws -> String = { _ in
           XCTestDynamicOverlay.XCTFail("Unimplemented: 'fetch'")
           throw DependenciesMacros.Unimplemented("fetch")
         }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -944,4 +944,50 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
     }
   }
+
+  func testWillSet() {
+    assertMacro {
+      """
+      struct Blah {
+        @DependencyEndpoint
+        public var foo: () throws -> Void {
+          willSet {
+            print("!")
+          }
+        }
+      }
+      """
+    } expansion: {
+      """
+      struct Blah {
+        public var foo: () throws -> Void {
+          willSet {
+            print("!")
+          }
+          @storageRestrictions(initializes: _foo)
+          init(initialValue) {
+            _foo = initialValue
+          }
+
+          get {
+            _foo
+          }
+
+          set {
+            _foo = newValue
+          }
+        }
+
+        private var _foo: () throws -> Void = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'foo'")
+          throw DependenciesMacros.Unimplemented("foo")
+        } {
+                willSet {
+                    print("!")
+                }
+          }
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
- `@DependencyClient` should ignore `let` bindings
- `@DependencyClient` should ignore explicit `get { … }` accessors (fixes #162)
- `@DependencyEndpoint` should preserve `willSet`/`didSet` accessors