### PR TITLE
Clearer warning message

### DIFF
--- a/Sources/DependenciesMacrosPlugin/Support.swift
+++ b/Sources/DependenciesMacrosPlugin/Support.swift
@@ -96,8 +96,9 @@ extension InitializerClauseSyntax {
             node: self.value,
             message: MacroExpansionWarningMessage(
               """
-              Do not use 'unimplemented' with '@\(attribute.attributeName)'; it is a replacement and \
-              implements the same runtime functionality as 'unimplemented' at compile time
+              Do not use 'unimplemented' with '@\(attribute.attributeName)'; the \
+              '@\(attribute.attributeName)' macro already includes the behavior of \
+              'unimplemented'.
               """
             )
           )

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -875,7 +875,7 @@ final class DependencyClientMacroTests: BaseTestCase {
         var bar: () -> Int = unimplemented()
                              ┬──────────────
                              ├─ 🛑 '@DependencyClient' default must be closure literal
-                             ╰─ ⚠️ Do not use 'unimplemented' with '@DependencyClient'; it is a replacement and implements the same runtime functionality as 'unimplemented' at compile time
+                             ╰─ ⚠️ Do not use 'unimplemented' with '@DependencyClient'; the '@DependencyClient' macro already includes the behavior of 'unimplemented'.
       }
       """
     }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -717,7 +717,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         var bar: () -> Int = unimplemented()
                              ┬──────────────
                              ├─ 🛑 '@DependencyEndpoint' default must be closure literal
-                             ╰─ ⚠️ Do not use 'unimplemented' with '@DependencyEndpoint'; it is a replacement and implements the same runtime functionality as 'unimplemented' at compile time
+                             ╰─ ⚠️ Do not use 'unimplemented' with '@DependencyEndpoint'; the '@DependencyEndpoint' macro already includes the behavior of 'unimplemented'.
       }
       """
     }


### PR DESCRIPTION
Old warning message:

>Do not use 'unimplemented' with '@DependencyClient'; it is a replacement and implements the same runtime functionality as 'unimplemented' at compile time

This was confusing because it was not clear what “it” referred to, nor what was a “replacement” for what.

New warning message:

>Do not use 'unimplemented' with '@DependencyEndpoint'; the '@DependencyEndpoint' macro provides an 'unimplemented' default value for you.

I also added a period at the end, but I can remove it if it’s not consistent with project style.