### PR TITLE
Dependencies: dynamically link XCTest

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(
       name: "DependenciesMacros",
       targets: ["DependenciesMacros"]
-    )
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-syntax", from: "509.0.0"),
@@ -31,6 +31,12 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
   ],
   targets: [
+    .target(
+      name: "DependenciesTestObserver",
+      dependencies: [
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      ]
+    ),
     .target(
       name: "Dependencies",
       dependencies: [
@@ -83,6 +89,16 @@ let package = Package(
   package.dependencies.append(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   )
+#endif
+
+#if !os(macOS) && !os(WASI)
+package.products.append(
+  .library(
+    name: "DependenciesTestObserver",
+    type: .dynamic,
+    targets: ["DependenciesTestObserver"]
+  )
+)
 #endif
 
 //for target in package.targets {

--- a/Sources/DependenciesTestObserver/TestObserver.swift
+++ b/Sources/DependenciesTestObserver/TestObserver.swift
@@ -1,0 +1,22 @@
+
+import XCTest
+import XCTestDynamicOverlay
+
+#if !_runtime(_ObjC)
+  final class TestObserver: NSObject, XCTestObservation {
+    private let resetCache: @convention(c) () -> Void
+    internal init(_ resetCache: @convention(c) () -> Void) {
+      self.resetCache = resetCache
+    }
+    public func testCaseWillStart(_ testCase: XCTestCase) {
+      self.resetCache()
+    }
+  }
+#endif
+
+public func registerTestObserver(_ resetCache: @convention(c) () -> Void) {
+  guard _XCTIsTesting else { return }
+  #if !_runtime(_ObjC)
+    XCTestObservationCenter.shared.addTestObserver(TestObserver(resetCache))
+  #endif
+}


### PR DESCRIPTION
Use delayed dynamic linking for registering the test observer. This is particularly important for Windows which does not support weak linking and weak symbols. Even in the case that `Dependencies` is imported due to use, we will not pull in the test observer until runtime, as a best effort. If the DependenciesTestObserver library is found in the search path, it will be loaded and the observer initialised. If we can't find the library, we will simply continue without the test observer.