### PR TITLE
Tests: simplify WASI handling in DependencyValues test

### DIFF
--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -593,32 +593,22 @@ final class DependencyValuesTests: XCTestCase {
   }
 
   #if DEBUG
-    // NB: Wasm has different behavior here.
-    #if os(WASI)
-      func testCachePollution1() async {
-        @Dependency(\.cachedDependency) var cachedDependency: CachedDependency
-        let value = await cachedDependency.increment()
-        XCTAssertEqual(value, 1)
-      }
+    func testCachePollution1() async {
+      @Dependency(\.cachedDependency) var cachedDependency: CachedDependency
+      let value = await cachedDependency.increment()
+      XCTAssertEqual(value, 1)
+    }
 
-      func testCachePollution2() async {
-        @Dependency(\.cachedDependency) var cachedDependency: CachedDependency
-        let value = await cachedDependency.increment()
-        XCTAssertEqual(value, 2)
-      }
-    #else
-      func testCachePollution1() async {
-        @Dependency(\.cachedDependency) var cachedDependency: CachedDependency
-        let value = await cachedDependency.increment()
-        XCTAssertEqual(value, 1)
-      }
-
-      func testCachePollution2() async {
-        @Dependency(\.cachedDependency) var cachedDependency: CachedDependency
-        let value = await cachedDependency.increment()
-        XCTAssertEqual(value, 1)
-      }
-    #endif
+    func testCachePollution2() async {
+      @Dependency(\.cachedDependency) var cachedDependency: CachedDependency
+      let value = await cachedDependency.increment()
+      // NB: Wasm has different behavior here.
+      #if os(WASI)
+          XCTAssertEqual(value, 2)
+      #else
+          XCTAssertEqual(value, 1)
+      #endif
+    }
   #endif
 
   func testThreadSafety() async {


### PR DESCRIPTION
The tests were duplicated rather than just isolating the behavioural difference between WASI and non-WASI targets. Simplify to avoid duplicating the entire test.