### PR TITLE
Add support for `@Dependency(MyDependency.self)`

### DIFF
--- a/Sources/Dependencies/Dependency.swift
+++ b/Sources/Dependencies/Dependency.swift
@@ -155,18 +155,6 @@ public struct Dependency<Value>: @unchecked Sendable, _HasInitialValues {
   }
 }
 
-extension Dependency: Equatable where Value: Equatable {
-  public static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.wrappedValue == rhs.wrappedValue
-  }
-}
-
-extension Dependency: Hashable where Value: Hashable {
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(self.wrappedValue)
-  }
-}
-
 fileprivate extension DependencyValues {
   subscript<Key: TestDependencyKey>(_: KeyPath<Key, Key>) -> Key.Value {
     get { self[Key.self] }

--- a/Sources/Dependencies/Dependency.swift
+++ b/Sources/Dependencies/Dependency.swift
@@ -1,3 +1,21 @@
+struct TrivialHashable<T>: Hashable, DependencyKey {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(T.self))
+  }
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    true
+  }
+  static var liveValue: T {
+    fatalError()
+  }
+}
+
+extension Dependency {
+  init(_ type: Value.Type) {
+    self.init(\DependencyValues.[TrivialHashable<Value>()])
+  }
+}
+
 /// A property wrapper for accessing dependencies.
 ///
 /// All dependencies are stored in ``DependencyValues`` and one uses this property wrapper to gain

--- a/Sources/Dependencies/Dependency.swift
+++ b/Sources/Dependencies/Dependency.swift
@@ -130,7 +130,12 @@ public struct Dependency<Value>: @unchecked Sendable, _HasInitialValues {
     fileID: StaticString = #fileID,
     line: UInt = #line
   ) where Key.Value == Value {
-    self.init(\DependencyValues.[\Key.self], file: file, fileID: fileID, line: line)
+    self.init(
+      \DependencyValues.[HashableType<Key>(file: file, line: line)],
+      file: file,
+      fileID: fileID,
+      line: line
+    )
   }
 
   /// The current value of the dependency property.
@@ -155,10 +160,21 @@ public struct Dependency<Value>: @unchecked Sendable, _HasInitialValues {
   }
 }
 
+private struct HashableType<T>: Hashable {
+  let file: StaticString
+  let line: UInt
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    true
+  }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(T.self))
+  }
+}
+
 fileprivate extension DependencyValues {
-  subscript<Key: TestDependencyKey>(_: KeyPath<Key, Key>) -> Key.Value {
-    get { self[Key.self] }
-    set { self[Key.self] = newValue }
+  subscript<Key: TestDependencyKey>(key: HashableType<Key>) -> Key.Value {
+    get { self[Key.self, file: key.file, line: key.line] }
+    set { self[Key.self, file: key.file, line: key.line] = newValue }
   }
 }
 

--- a/Sources/Dependencies/Dependency.swift
+++ b/Sources/Dependencies/Dependency.swift
@@ -1,21 +1,3 @@
-struct TrivialHashable<T>: Hashable, DependencyKey {
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(ObjectIdentifier(T.self))
-  }
-  static func == (lhs: Self, rhs: Self) -> Bool {
-    true
-  }
-  static var liveValue: T {
-    fatalError()
-  }
-}
-
-extension Dependency {
-  init(_ type: Value.Type) {
-    self.init(\DependencyValues.[TrivialHashable<Value>()])
-  }
-}
-
 /// A property wrapper for accessing dependencies.
 ///
 /// All dependencies are stored in ``DependencyValues`` and one uses this property wrapper to gain
@@ -113,6 +95,10 @@ public struct Dependency<Value>: @unchecked Sendable, _HasInitialValues {
     self.file = file
     self.fileID = fileID
     self.line = line
+  }
+
+  public init(_ type: Value.Type) {
+    self.init(\DependencyValues.[ObjectIdentifier(Value.self)])
   }
 
   /// The current value of the dependency property.

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -210,25 +210,30 @@ extension DependencyKey {
               \(typeName(Value.self))
           """
       )
-      let dependencyName =
+
+      let (argument, override) =
         DependencyValues.currentDependency.name
-        .map { "@Dependency(\\.\($0))" }
-        ?? "A dependency"
+        .map {
+          "\($0)" == "subscript(_:)"
+            ? ("@Dependency(\(typeName(Self.self)).self)", "'\(typeName(Self.self)).self'")
+            : ("@Dependency(\\.\($0))", "'\($0)'")
+        }
+        ?? ("A dependency", "the dependency")
+
       XCTFail(
         """
-        \(dependencyName) has no test implementation, but was accessed from a test context:
+        \(argument) has no test implementation, but was accessed from a test context:
 
         \(dependencyDescription)
 
         Dependencies registered with the library are not allowed to use their default, live \
         implementations when run from tests.
 
-        To fix, override \
-        \(DependencyValues.currentDependency.name.map { "'\($0)'" } ?? "the dependency") with a \
-        test value. If you are using the Composable Architecture, mutate the 'dependencies' \
-        property on your 'TestStore'. Otherwise, use 'withDependencies' to define a scope for the \
-        override. If you'd like to provide a default value for all tests, implement the \
-        'testValue' requirement of the 'DependencyKey' protocol.
+        To fix, override \(override) with a test value. If you are using the \
+        Composable Architecture, mutate the 'dependencies' property on your 'TestStore'. \
+        Otherwise, use 'withDependencies' to define a scope for the override. If you'd like to \
+        provide a default value for all tests, implement the 'testValue' requirement of the \
+        'DependencyKey' protocol.
         """
       )
     #endif

--- a/Sources/Dependencies/DependencyKey.swift
+++ b/Sources/Dependencies/DependencyKey.swift
@@ -58,7 +58,7 @@
 /// implementation module.
 ///
 /// See the <doc:LivePreviewTest> article for more information.
-public protocol DependencyKey: TestDependencyKey {
+public protocol DependencyKey<Value>: TestDependencyKey {
   /// The live value for the dependency key.
   ///
   /// This is the value used by default when running the application in a simulator or on a device.
@@ -118,7 +118,7 @@ public protocol DependencyKey: TestDependencyKey {
 /// return a default value suitable for Xcode previews, or the ``testValue``, if left unimplemented.
 ///
 /// See ``DependencyKey`` to define a static, default value for the live application.
-public protocol TestDependencyKey {
+public protocol TestDependencyKey<Value> {
   /// The associated type representing the type of the dependency key's value.
   associatedtype Value: Sendable = Self
 

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTestDynamicOverlay
 
 /// A collection of dependencies that is globally available.
 ///
@@ -129,9 +130,9 @@ public struct DependencyValues: Sendable {
   /// property wrapper.
   public subscript<Key: TestDependencyKey>(
     key: Key.Type,
-    file: StaticString = #file,
-    function: StaticString = #function,
-    line: UInt = #line
+    file file: StaticString = #file,
+    function function: StaticString = #function,
+    line line: UInt = #line
   ) -> Key.Value where Key.Value: Sendable {
     get {
       guard let base = self.storage[ObjectIdentifier(key)]?.base,
@@ -279,87 +280,89 @@ private final class CachedValues: @unchecked Sendable {
     function: StaticString = #function,
     line: UInt = #line
   ) -> Key.Value where Key.Value: Sendable {
-    self.lock.lock()
-    defer { self.lock.unlock() }
+    XCTFailContext.$current.withValue(XCTFailContext(file: file, line: line)) {
+      self.lock.lock()
+      defer { self.lock.unlock() }
 
-    let cacheKey = CacheKey(id: ObjectIdentifier(key), context: context)
-    guard let base = self.cached[cacheKey]?.base, let value = base as? Key.Value
-    else {
-      let value: Key.Value?
-      switch context {
-      case .live:
-        value = _liveValue(key) as? Key.Value
-      case .preview:
-        value = Key.previewValue
-      case .test:
-        value = Key.testValue
-      }
-
-      guard let value = value
+      let cacheKey = CacheKey(id: ObjectIdentifier(key), context: context)
+      guard let base = self.cached[cacheKey]?.base, let value = base as? Key.Value
       else {
-        #if DEBUG
-          if !DependencyValues.isSetting {
-            var dependencyDescription = ""
-            if let fileID = DependencyValues.currentDependency.fileID,
-              let line = DependencyValues.currentDependency.line
-            {
-              dependencyDescription.append(
-                """
-                  Location:
-                    \(fileID):\(line)
+        let value: Key.Value?
+        switch context {
+        case .live:
+          value = _liveValue(key) as? Key.Value
+        case .preview:
+          value = Key.previewValue
+        case .test:
+          value = Key.testValue
+        }
 
+        guard let value = value
+        else {
+          #if DEBUG
+            if !DependencyValues.isSetting {
+              var dependencyDescription = ""
+              if let fileID = DependencyValues.currentDependency.fileID,
+                let line = DependencyValues.currentDependency.line
+              {
+                dependencyDescription.append(
+                  """
+                    Location:
+                      \(fileID):\(line)
+
+                  """
+                )
+              }
+              dependencyDescription.append(
+                Key.self == Key.Value.self
+                  ? """
+                    Dependency:
+                      \(typeName(Key.Value.self))
+                  """
+                  : """
+                    Key:
+                      \(typeName(Key.self))
+                    Value:
+                      \(typeName(Key.Value.self))
+                  """
+              )
+
+              var argument: String {
+                "\(function)" == "subscript(_:)" ? "\(typeName(Key.self)).self" : "\\.\(function)"
+              }
+
+              runtimeWarn(
                 """
+                @Dependency(\(argument)) has no live implementation, but was accessed from a live \
+                context.
+
+                \(dependencyDescription)
+
+                Every dependency registered with the library must conform to 'DependencyKey', and \
+                that conformance must be visible to the running application.
+
+                To fix, make sure that '\(typeName(Key.self))' conforms to 'DependencyKey' by \
+                providing a live implementation of your dependency, and make sure that the \
+                conformance is linked with this current application.
+                """,
+                file: DependencyValues.currentDependency.file ?? file,
+                line: DependencyValues.currentDependency.line ?? line
               )
             }
-            dependencyDescription.append(
-              Key.self == Key.Value.self
-                ? """
-                  Dependency:
-                    \(typeName(Key.Value.self))
-                """
-                : """
-                  Key:
-                    \(typeName(Key.self))
-                  Value:
-                    \(typeName(Key.Value.self))
-                """
-            )
-
-            var argument: String {
-              "\(function)" == "subscript(_:)" ? "\(typeName(Key.self)).self" : "\\.\(function)"
-            }
-
-            runtimeWarn(
-              """
-              @Dependency(\(argument)) has no live implementation, but was accessed from a live \
-              context.
-
-              \(dependencyDescription)
-
-              Every dependency registered with the library must conform to 'DependencyKey', and \
-              that conformance must be visible to the running application.
-
-              To fix, make sure that '\(typeName(Key.self))' conforms to 'DependencyKey' by \
-              providing a live implementation of your dependency, and make sure that the \
-              conformance is linked with this current application.
-              """,
-              file: DependencyValues.currentDependency.file ?? file,
-              line: DependencyValues.currentDependency.line ?? line
-            )
+          #endif
+          let value = Key.testValue
+          if !DependencyValues.isSetting {
+            self.cached[cacheKey] = AnySendable(value)
           }
-        #endif
-        let value = Key.testValue
-        if !DependencyValues.isSetting {
-          self.cached[cacheKey] = AnySendable(value)
+          return value
         }
+
+        self.cached[cacheKey] = AnySendable(value)
         return value
       }
 
-      self.cached[cacheKey] = AnySendable(value)
       return value
     }
-
-    return value
   }
 }
 

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -100,6 +100,17 @@ public struct DependencyValues: Sendable {
     #endif
   }
 
+  subscript<Value: Sendable>(
+    key: TrivialHashable<Value>
+  ) -> Value {
+    get {
+      self.storage[ObjectIdentifier(TrivialHashable<Value>.self)]!.base as! Value
+    }
+    set {
+      self.storage[ObjectIdentifier(TrivialHashable<Value>.self)] = AnySendable(newValue)
+    }
+  }
+
   /// Accesses the dependency value associated with a custom key.
   ///
   /// This subscript is typically only used when adding a computed property to ``DependencyValues``

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -101,23 +101,9 @@ public struct DependencyValues: Sendable {
   }
 
   @_disfavoredOverload
-  public subscript<Value: Sendable>(type: Value.Type) -> Value {
-    get {
-      self[ObjectIdentifier(type)]
-    }
-    set {
-      self[ObjectIdentifier(type)] = newValue
-    }
-  }
-
-  subscript<Value: Sendable>(id: ObjectIdentifier) -> Value {
-    get {
-      // TODO: better error messaging for type mismatch
-      self.storage[id]?.base as! Value
-    }
-    set {
-      self.storage[id] = AnySendable(newValue)
-    }
+  public subscript<Key: TestDependencyKey>(type: Key.Type) -> Key.Value {
+    get { self[type] }
+    set { self[type] = newValue }
   }
 
   /// Accesses the dependency value associated with a custom key.

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -331,15 +331,15 @@ private final class CachedValues: @unchecked Sendable {
 
             runtimeWarn(
               """
-              "@Dependency(\(argument))" has no live implementation, but was accessed from a live \
+              @Dependency(\(argument)) has no live implementation, but was accessed from a live \
               context.
 
               \(dependencyDescription)
 
-              Every dependency registered with the library must conform to "DependencyKey", and \
+              Every dependency registered with the library must conform to 'DependencyKey', and \
               that conformance must be visible to the running application.
 
-              To fix, make sure that "\(typeName(Key.self))" conforms to "DependencyKey" by \
+              To fix, make sure that '\(typeName(Key.self))' conforms to 'DependencyKey' by \
               providing a live implementation of your dependency, and make sure that the \
               conformance is linked with this current application.
               """,

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -344,7 +344,11 @@ private final class CachedValues: @unchecked Sendable {
             )
           }
         #endif
-        return Key.testValue
+        let value = Key.testValue
+        if !DependencyValues.isSetting {
+          self.cached[cacheKey] = AnySendable(value)
+        }
+        return value
       }
 
       self.cached[cacheKey] = AnySendable(value)

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -100,15 +100,14 @@ public struct DependencyValues: Sendable {
     #endif
   }
 
-  subscript<Value: Sendable>(
-    key: TrivialHashable<Value>
-  ) -> Value {
-    get {
-      self.storage[ObjectIdentifier(TrivialHashable<Value>.self)]!.base as! Value
-    }
-    set {
-      self.storage[ObjectIdentifier(TrivialHashable<Value>.self)] = AnySendable(newValue)
-    }
+  public subscript<Value: Sendable>(type: Value.Type) -> Value {
+    get { self[ObjectIdentifier(type)] }
+    set { self[ObjectIdentifier(type)] = newValue }
+  }
+
+  subscript<Value: Sendable>(id: ObjectIdentifier) -> Value {
+    get { self.storage[id]?.base as! Value }
+    set { self.storage[id] = AnySendable(newValue) }
   }
 
   /// Accesses the dependency value associated with a custom key.

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -100,14 +100,24 @@ public struct DependencyValues: Sendable {
     #endif
   }
 
+  @_disfavoredOverload
   public subscript<Value: Sendable>(type: Value.Type) -> Value {
-    get { self[ObjectIdentifier(type)] }
-    set { self[ObjectIdentifier(type)] = newValue }
+    get {
+      self[ObjectIdentifier(type)]
+    }
+    set {
+      self[ObjectIdentifier(type)] = newValue
+    }
   }
 
   subscript<Value: Sendable>(id: ObjectIdentifier) -> Value {
-    get { self.storage[id]?.base as! Value }
-    set { self.storage[id] = AnySendable(newValue) }
+    get {
+      // TODO: better error messaging for type mismatch
+      self.storage[id]?.base as! Value
+    }
+    set {
+      self.storage[id] = AnySendable(newValue)
+    }
   }
 
   /// Accesses the dependency value associated with a custom key.

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -82,9 +82,7 @@ import XCTestDynamicOverlay
 /// Read the article <doc:RegisteringDependencies> for more information.
 public struct DependencyValues: Sendable {
   @TaskLocal public static var _current = Self()
-  #if DEBUG
-    @TaskLocal static var isSetting = false
-  #endif
+  @TaskLocal static var isSetting = false
   @TaskLocal static var currentDependency = CurrentDependency()
 
   fileprivate var cachedValues = CachedValues()

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -325,10 +325,14 @@ private final class CachedValues: @unchecked Sendable {
                 """
             )
 
+            var argument: String {
+              "\(function)" == "subscript(_:)" ? "\(typeName(Key.self)).self" : "\\.\(function)"
+            }
+
             runtimeWarn(
               """
-              "@Dependency(\\.\(function))" has no live implementation, but was accessed from a \
-              live context.
+              "@Dependency(\(argument))" has no live implementation, but was accessed from a live \
+              context.
 
               \(dependencyDescription)
 

--- a/Tests/DependenciesTests/DependencyTests.swift
+++ b/Tests/DependenciesTests/DependencyTests.swift
@@ -211,7 +211,7 @@ final class DependencyTests: XCTestCase {
     struct MyDependency: TestDependencyKey {
       static var testValue: Int { 0 }
     }
-    @Dependency(MyDependency.self) var int
+    @Dependency(MyDependency.self) var int: Int
 
     XCTAssertEqual(int, 0)
 

--- a/Tests/DependenciesTests/DependencyTests.swift
+++ b/Tests/DependenciesTests/DependencyTests.swift
@@ -206,6 +206,18 @@ final class DependencyTests: XCTestCase {
     XCTAssertEqual(user1.id, UUID(0))
     XCTAssertEqual(user2.id, UUID(1))
   }
+
+  func testOptionalDependency() {
+    @Dependency(Int?.self) var int
+
+    XCTAssertNil(int)
+
+    withDependencies {
+      $0[Int?.self] = 42
+    } operation: {
+      XCTAssertEqual(int, 42)
+    }
+  }
 }
 
 private class Model {

--- a/Tests/DependenciesTests/DependencyTests.swift
+++ b/Tests/DependenciesTests/DependencyTests.swift
@@ -207,13 +207,16 @@ final class DependencyTests: XCTestCase {
     XCTAssertEqual(user2.id, UUID(1))
   }
 
-  func testOptionalDependency() {
-    @Dependency(Int?.self) var int
+  func testDependencyType() {
+    struct MyDependency: TestDependencyKey {
+      static var testValue: Int { 0 }
+    }
+    @Dependency(MyDependency.self) var int
 
-    XCTAssertNil(int)
+    XCTAssertEqual(int, 0)
 
     withDependencies {
-      $0[Int?.self] = 42
+      $0[MyDependency.self] = 42
     } operation: {
       XCTAssertEqual(int, 42)
     }

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -177,11 +177,7 @@ final class DependencyValuesTests: XCTestCase {
             #endif
             XCTAssertEqual(reuseClient.count(), 0)
             reuseClient.setCount(-42)
-            XCTAssertEqual(
-              reuseClient.count(),
-              0,
-              "Don't cache dependency when using a test value in a live context"
-            )
+            XCTAssertEqual(reuseClient.count(), -42)
           }
 
           XCTAssertEqual(reuseClient.count(), 42)

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -27,7 +27,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       } issueMatcher: {
         $0.compactDescription == """
-          "@Dependency(\\.missingLiveDependency)" has no live implementation, but was accessed \
+          @Dependency(\\.missingLiveDependency) has no live implementation, but was accessed \
           from a live context.
 
             Location:
@@ -37,10 +37,44 @@ final class DependencyValuesTests: XCTestCase {
             Value:
               Int
 
-          Every dependency registered with the library must conform to "DependencyKey", and that \
+          Every dependency registered with the library must conform to 'DependencyKey', and that \
           conformance must be visible to the running application.
 
-          To fix, make sure that "TestKey" conforms to "DependencyKey" by providing a live \
+          To fix, make sure that 'TestKey' conforms to 'DependencyKey' by providing a live \
+          implementation of your dependency, and make sure that the conformance is linked with \
+          this current application.
+          """
+      }
+    #endif
+  }
+
+  func testMissingLiveValue_Type() {
+    #if DEBUG && !os(Linux) && !os(WASI) && !os(Windows)
+      var line = 0
+      XCTExpectFailure {
+        withDependencies {
+          $0.context = .live
+        } operation: {
+          line = #line + 1
+          @Dependency(TestKey.self) var missingLiveDependency: Int
+          _ = missingLiveDependency
+        }
+      } issueMatcher: {
+        $0.compactDescription == """
+          @Dependency(TestKey.self) has no live implementation, but was accessed from a live \
+          context.
+
+            Location:
+              DependenciesTests/DependencyValuesTests.swift:\(line)
+            Key:
+              TestKey
+            Value:
+              Int
+
+          Every dependency registered with the library must conform to 'DependencyKey', and that \
+          conformance must be visible to the running application.
+
+          To fix, make sure that 'TestKey' conforms to 'DependencyKey' by providing a live \
           implementation of your dependency, and make sure that the conformance is linked with \
           this current application.
           """
@@ -169,7 +203,7 @@ final class DependencyValuesTests: XCTestCase {
               XCTExpectFailure {
                 $0.compactDescription.contains(
                   """
-                  @Dependency(\\.reuseClient)" has no live implementation, but was accessed from a \
+                  @Dependency(\\.reuseClient) has no live implementation, but was accessed from a \
                   live context.
                   """
                 )
@@ -201,8 +235,8 @@ final class DependencyValuesTests: XCTestCase {
             XCTExpectFailure {
               $0.compactDescription.contains(
                 """
-                @Dependency(\\.reuseClient)" has no live implementation, but was accessed from a live \
-                context.
+                @Dependency(\\.reuseClient) has no live implementation, but was accessed from a \
+                live context.
                 """
               )
             }


### PR DESCRIPTION
Now that `@Environment` supports a shorthand for objects, we should do similar in our library.

This PR allows you to skip the step of extending `DependencyValues` with a key path and instead rely directly on the dependency key, which usually aligns with the value.

```diff
 extension APIClient: DependencyKey {
   var liveValue: Self { … }
 }

-extension DependencyValues {
-  var apiClient: APIClient {
-    get { self[APIClient.self] }
-    set { self[APIClient.self] = newValue }
-  }
-}
-
 class MyModel {
-  @Dependency(\.apiClient) var apiClient
+  @Dependency(APIClient.self) var apiClient
```

This new API is less discoverable and friendly to autocomplete, but may be appropriate for application code that refers to a singleton type, and can save that bit of boilerplate above.