### PR TITLE
Support new access modifier package swift 5.9

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -243,7 +243,7 @@ extension DeclModifierListSyntax {
         switch $0.name.tokenKind {
         case .keyword(let keyword):
           switch keyword {
-          case .fileprivate, .private, .internal, .public:
+              case .fileprivate, .private, .internal, .package, .public:
             return false
           default:
             return true

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -998,4 +998,36 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """
     }
   }
+    
+  func testAccessPackage() {
+    assertMacro {
+      """
+      package struct Client {
+        @DependencyEndpoint
+        package var endpoint: () -> Void
+      }
+      """
+    } expansion: {
+      """
+      package struct Client {
+        package var endpoint: () -> Void {
+          @storageRestrictions(initializes: _endpoint)
+          init(initialValue) {
+            _endpoint = initialValue
+          }
+          get {
+            _endpoint
+          }
+          set {
+            _endpoint = newValue
+          }
+        }
+
+        private var _endpoint: () -> Void = {
+          XCTestDynamicOverlay.XCTFail("Unimplemented: 'endpoint'")
+        }
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
- Modify DependencyEndpoint macro to support new access modifier package