### PR TITLE
Fix assigned static properties

### DIFF
--- a/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
-        "version" : "1.0.2"
+        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -86,7 +86,11 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
     var hasEndpoints = false
     var accesses: Set<Access> = Access(modifiers: declaration.modifiers).map { [$0] } ?? []
     for member in declaration.memberBlock.members {
-      guard var property = member.decl.as(VariableDeclSyntax.self) else { continue }
+      guard
+        var property = member.decl.as(VariableDeclSyntax.self),
+        !property.isStatic
+      else { continue }
+
       let isEndpoint =
         property.hasDependencyEndpointMacroAttached
         || property.bindingSpecifier.tokenKind != .keyword(.let) && property.isClosure
@@ -249,6 +253,12 @@ private struct Property {
 }
 
 extension VariableDeclSyntax {
+  fileprivate var isStatic: Bool {
+    self.modifiers.contains { modifier in
+      modifier.name.tokenKind == .keyword(.static)
+    }
+  }
+
   fileprivate var hasDependencyEndpointMacroAttached: Bool {
     self.attributes.contains {
       guard

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -276,6 +276,35 @@ final class DependencyClientMacroTests: BaseTestCase {
     }
   }
 
+  func testStaticVar() {
+    assertMacro {
+      """
+      @DependencyClient
+      struct Client {
+        var config: () -> Void
+        static var value = Client()
+      }
+      """
+    } expansion: {
+      """
+      struct Client {
+        @DependencyEndpoint
+        var config: () -> Void
+        static var value = Client()
+
+        init(
+          config: @escaping () -> Void
+        ) {
+          self.config = config
+        }
+
+        init() {
+        }
+      }
+      """
+    }
+  }
+
   func testDefaultValue() {
     assertMacro {
       """


### PR DESCRIPTION
Ensures that the `@DependencyClient` macro doesn't attempt to do anything with static properties.
The macro bails out of looking a specific member property if the member is `static`. Wouldn't make sense to try and include them in the initialiser or add the `@DependencyEndpoint` to them, so I figured it was worth just bailing as quickly as possible on them.

I did notice that some of the other unit tests, the DependencyEndpoint tests, are failing. They were failing before I did any of this work though.

As discussed in the Slack, without this, assigned static properties in the form: `static var prop = SomeValue()` will crash the compiler, as they're treated the exact same as `var prop: SomeValue = SomeValue()`.

![image](https://github.com/pointfreeco/swift-dependencies/assets/11096937/e8f150db-8f2e-4bc3-be2c-ea64768ff710)
