### PR TITLE
Fix dependency value type in documentation

### DIFF
--- a/Sources/Dependencies/Documentation.docc/Articles/RegisteringDependencies.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/RegisteringDependencies.md
@@ -131,7 +131,7 @@ If you extend dependency values with a dedicated key path, you can even make thi
 +private enum UserDefaultsKey: DependencyKey { /* ... */ }
 +
 +extension DependencyValues {
-+  var userDefaults: APIClient {
++  var userDefaults: UserDefaults {
 +    get { self[UserDefaultsKey.self] }
 +    set { self[UserDefaultsKey.self] = newValue }
 +  }


### PR DESCRIPTION
In the context of this explanation, using `UserDefaults` seems more suitable than `APIClient`.