### PR TITLE
Add NotificationCenter dependency value

### DIFF
--- a/Sources/Dependencies/DependencyValues/NotificationCenter.swift
+++ b/Sources/Dependencies/DependencyValues/NotificationCenter.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension DependencyValues {
+  /// The current notification center to be used for delivering notifications.
+  ///
+  /// By default, the notificationCenter returned from `NotificationCenter.default` is supplied. When used
+  /// in a testing context, access will call to `XCTFail` when invoked, unless explicitly overridden
+  /// using ``withDependencies(_:operation:)-4uz6m``:
+  ///
+  /// ```swift
+  /// // Provision model with overridden dependencies
+  /// let notificationCenter: NotificationCenter = .init()
+  /// let model = withDependencies {
+  ///   $0.notificationCenter = notificationCenter
+  /// } operation: {
+  ///   FeatureModel()
+  /// }
+  ///
+  /// // Make assertions with model...
+  /// ```
+  public var notificationCenter: NotificationCenter {
+    get { self[NotificationCenterKey.self] }
+    set { self[NotificationCenterKey.self] = newValue }
+  }
+
+  private enum NotificationCenterKey: DependencyKey {
+    static let liveValue = NotificationCenter.default
+  }
+}

--- a/Sources/swift-dependencies-benchmark/WithValue.swift
+++ b/Sources/swift-dependencies-benchmark/WithValue.swift
@@ -7,6 +7,7 @@ let withValueSuite = BenchmarkSuite(name: "Dependencies") { suite in
   _ = DependencyValues._current.calendar
   _ = DependencyValues._current.context
   _ = DependencyValues._current.locale
+  _ = DependencyValues._current.notificationCenter
   _ = DependencyValues._current.timeZone
   _ = DependencyValues._current.urlSession
   _ = DependencyValues._current.uuid


### PR DESCRIPTION
We often use NotificationCenter to broadcast notifications in the app, so it would be useful to have it as a dependency.