### PR TITLE
Fix sendable warnings.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,14 +55,3 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   )
 #endif
-
-//for target in package.targets {
-//  target.swiftSettings = target.swiftSettings ?? []
-//  target.swiftSettings?.append(
-//    .unsafeFlags([
-//      "-Xfrontend", "-warn-concurrency",
-//      "-Xfrontend", "-enable-actor-data-race-checks",
-//      "-enable-library-evolution",
-//    ])
-//  )
-//}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -113,7 +113,6 @@ for target in package.targets {
   target.swiftSettings?.append(.enableExperimentalFeature("StrictConcurrency"))
 //  target.swiftSettings?.append(
 //    .unsafeFlags([
-//      "-Xfrontend", "-enable-actor-data-race-checks",
 //      "-enable-library-evolution",
 //    ])
 //  )

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -108,13 +108,13 @@ let package = Package(
   )
 #endif
 
-//for target in package.targets {
-//  target.swiftSettings = target.swiftSettings ?? []
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(.enableExperimentalFeature("StrictConcurrency"))
 //  target.swiftSettings?.append(
 //    .unsafeFlags([
-//      "-Xfrontend", "-warn-concurrency",
 //      "-Xfrontend", "-enable-actor-data-race-checks",
 //      "-enable-library-evolution",
 //    ])
 //  )
-//}
+}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -110,7 +110,9 @@ let package = Package(
 
 for target in package.targets {
   target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings?.append(.enableExperimentalFeature("StrictConcurrency"))
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
 //  target.swiftSettings?.append(
 //    .unsafeFlags([
 //      "-enable-library-evolution",

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -326,9 +326,9 @@ private class DependencyObjects: @unchecked Sendable {
   internal init() {}
 
   func store(_ object: AnyObject) {
-    self.storage.withValue { storage in
-      storage[ObjectIdentifier(object)] = DependencyObject(
-        object: object,
+    self.storage.withValue { [id = ObjectIdentifier(object), object = UncheckedSendable(object)] storage in
+      storage[id] = DependencyObject(
+        object: object.wrappedValue,
         dependencyValues: DependencyValues._current
       )
       Task {
@@ -347,7 +347,9 @@ private class DependencyObjects: @unchecked Sendable {
       .compactMap({ $1 as? _HasInitialValues })
       .first?
       .initialValues
-      ?? self.storage.withValue({ $0[ObjectIdentifier(object)]?.dependencyValues })
+    ?? self.storage.withValue({ [id = ObjectIdentifier(object)] in
+      $0[id]?.dependencyValues
+    })
   }
 }
 

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -436,10 +436,10 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = withDependencies {
+      let model = await withDependencies {
         $0.fullDependency.value = 42
       } operation: {
-        FeatureModel()
+        await FeatureModel()
       }
 
       await model.doSomething(expectation: expectation)
@@ -466,7 +466,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = FeatureModel()
+      let model = await FeatureModel()
 
       await withDependencies {
         $0.fullDependency.value = 42
@@ -499,7 +499,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = FeatureModel()
+      let model = await FeatureModel()
 
       await withDependencies {
         $0.fullDependency.value = 42
@@ -526,7 +526,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = FeatureModel()
+      let model = await FeatureModel()
 
       await withDependencies {
         $0.fullDependency.value = 42

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -436,10 +436,10 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = await withDependencies {
+      let model = withDependencies {
         $0.fullDependency.value = 42
       } operation: {
-        await FeatureModel()
+        FeatureModel()
       }
 
       await model.doSomething(expectation: expectation)
@@ -466,7 +466,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = await FeatureModel()
+      let model = FeatureModel()
 
       await withDependencies {
         $0.fullDependency.value = 42
@@ -499,7 +499,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = await FeatureModel()
+      let model = FeatureModel()
 
       await withDependencies {
         $0.fullDependency.value = 42
@@ -526,7 +526,7 @@ final class DependencyValuesTests: XCTestCase {
         }
       }
 
-      let model = await FeatureModel()
+      let model = FeatureModel()
 
       await withDependencies {
         $0.fullDependency.value = 42


### PR DESCRIPTION
We only had 4 really simple sendable warnings, but 2 of them we can't fix until we remove a deprecated API.