### PR TITLE
Add support for package access modifier to DependencyClient macro

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -213,6 +213,7 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
 private enum Access: Comparable {
   case `private`
   case `internal`
+  case `package`
   case `public`
 
   init?(modifiers: DeclModifierListSyntax) {
@@ -223,6 +224,9 @@ private enum Access: Comparable {
         return
       case .keyword(.internal):
         self = .internal
+        return
+      case .keyword(.package):
+        self = .package
         return
       case .keyword(.public):
         self = .public
@@ -240,6 +244,8 @@ private enum Access: Comparable {
       return .keyword(.private)
     case .internal:
       return nil
+    case .package:
+      return .keyword(.package)
     case .public:
       return .keyword(.public)
     }

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -419,6 +419,33 @@ final class DependencyClientMacroTests: BaseTestCase {
     }
   }
 
+  func testPackage() {
+    assertMacro {
+      """
+      @DependencyClient
+      package struct Client {
+        package var endpoint: () -> Void
+      }
+      """
+    } expansion: {
+      """
+      package struct Client {
+        @DependencyEndpoint
+        package var endpoint: () -> Void
+
+        package init(
+          endpoint: @escaping () -> Void
+        ) {
+          self.endpoint = endpoint
+        }
+
+        package init() {
+        }
+      }
+      """
+    }
+  }
+
   func testSendable() {
     assertMacro {
       """


### PR DESCRIPTION
## Context
Hey folks 👋  It seems like the `@DependencyClient` macro doesn't support the `package` access modifier when generating `init`'s, which makes it harder to split the interface and implementation into two separate targets if the interface uses `package` access. This is because the generated init will have `internal` access.

## Changes
- Added `package` access modifier support to `DependencyClientMacro` 
- Added unit tests verifying the change 