### PR TITLE
DependencyClient - Ignore @Dependency and @DependencyEndpointIgnored properties

### DIFF
--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -209,6 +209,10 @@ public macro DependencyEndpoint(method: String = "") =
     module: "DependenciesMacrosPlugin", type: "DependencyEndpointMacro"
   )
 
+@attached(accessor, names: named(willSet))
+public macro DependencyEndpointIgnored() =
+  #externalMacro(module: "DependenciesMacrosPlugin", type: "DependencyEndpointIgnoredMacro")
+
 /// The error thrown by "unimplemented" closures produced by ``DependencyEndpoint(method:)``
 public struct Unimplemented: Error {
   let endpoint: String

--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -376,3 +376,16 @@ extension TupleTypeElementSyntax {
       .tokenKind == .keyword(.inout)
   }
 }
+
+public struct DependencyEndpointIgnoredMacro: AccessorMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: Declaration,
+    in context: Context
+  ) throws -> [AccessorDeclSyntax] {
+    return []
+  }
+}

--- a/Sources/DependenciesMacrosPlugin/Plugins.swift
+++ b/Sources/DependenciesMacrosPlugin/Plugins.swift
@@ -6,5 +6,6 @@ struct MacrosPlugin: CompilerPlugin {
   let providingMacros: [Macro.Type] = [
     DependencyClientMacro.self,
     DependencyEndpointMacro.self,
+    DependencyEndpointIgnoredMacro.self
   ]
 }


### PR DESCRIPTION
As discussed [on Slack](https://pointfreecommunity.slack.com/archives/C04L2D0MNJH/p1715002662552749), this PR adds two fixes:

1. A new `@DependencyEndpointIgnored` macro which can be used to skip a specific property from code generation
2. Automatically skip properties marked with `@Dependency` or `@DependencyEndpointIgnored`

I've added some tests and also tested it on my local use case which works well:

<img width="861" alt="image" src="https://github.com/pointfreeco/swift-dependencies/assets/605076/5bb2ce80-1347-449e-908c-aaec38159053">
