### PR TITLE
Remove insecure setters

### DIFF
--- a/Sources/Dependencies/DependencyValues/Assert.swift
+++ b/Sources/Dependencies/DependencyValues/Assert.swift
@@ -22,8 +22,7 @@ extension DependencyValues {
   /// }
   /// ```
   public var assert: any AssertionEffect {
-    get { self[AssertKey.self] }
-    set { self[AssertKey.self] = newValue }
+    self[AssertKey.self]
   }
 
   /// A dependency for failing an assertion.
@@ -56,8 +55,7 @@ extension DependencyValues {
   /// }
   /// ```
   public var precondition: any AssertionEffect {
-    get { self[PreconditionKey.self] }
-    set { self[PreconditionKey.self] = newValue }
+    self[PreconditionKey.self]
   }
 }
 
@@ -163,35 +161,4 @@ private enum AssertKey: DependencyKey {
 private enum PreconditionKey: DependencyKey {
   public static let liveValue: any AssertionEffect = LivePreconditionEffect()
   public static let testValue: any AssertionEffect = TestAssertionEffect()
-}
-
-/// An ``AssertionEffect`` that invokes the given closure.
-public struct AnyAssertionEffect: AssertionEffect {
-  private let assert:
-    @Sendable (
-      _ condition: @autoclosure () -> Bool,
-      _ message: @autoclosure () -> String,
-      _ file: StaticString,
-      _ line: UInt
-    ) -> Void
-
-  public init(
-    _ assert: @escaping @Sendable (
-      _ condition: @autoclosure () -> Bool,
-      _ message: @autoclosure () -> String,
-      _ file: StaticString,
-      _ line: UInt
-    ) -> Void
-  ) {
-    self.assert = assert
-  }
-
-  public func callAsFunction(
-    _ condition: @autoclosure () -> Bool,
-    _ message: @autoclosure () -> String,
-    file: StaticString,
-    line: UInt
-  ) {
-    self.assert(condition(), message(), file, line)
-  }
 }

--- a/Sources/Dependencies/DependencyValues/FireAndForget.swift
+++ b/Sources/Dependencies/DependencyValues/FireAndForget.swift
@@ -45,8 +45,7 @@ extension DependencyValues {
   /// Now this is easy to test. We just have to `await` for the code to finish, and once it does
   /// we can verify that the email was sent.
   public var fireAndForget: FireAndForget {
-    get { self[FireAndForgetKey.self] }
-    set { self[FireAndForgetKey.self] = newValue }
+    self[FireAndForgetKey.self]
   }
 }
 

--- a/Tests/DependenciesTests/AssertTests.swift
+++ b/Tests/DependenciesTests/AssertTests.swift
@@ -38,16 +38,4 @@ final class AssertTests: XCTestCase {
       }
     }
   #endif
-
-  func testCustom() {
-    let expectation = self.expectation(description: "assert")
-    withDependencies {
-      $0.assert = AnyAssertionEffect { condition, message, file, line in
-        expectation.fulfill()
-      }
-    } operation: {
-      assert(true)
-      self.wait(for: [expectation], timeout: 0)
-    }
-  }
 }


### PR DESCRIPTION
It is currently possible to override `fireAndForget`, `assert`, and `precondition`, but it is not safe to do so. You could accidentally introduce bad code into a release.

Because these helpers are specifically for making test behavior predictable, we should not allow custom behavior that can leak into a live app.