### PR TITLE
Extend `DependencyValues` to provide features an instance of `NotificationCenter` they can observe.

### DIFF
--- a/Sources/Dependencies/DependencyValues/NotificationCenter.swift
+++ b/Sources/Dependencies/DependencyValues/NotificationCenter.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension DependencyValues {
+  /// The `NotificationCenter` object features should observe notifications with.
+  ///
+  /// By default, the notification center returned from `NotificationCenter.default` is supplied. When used
+  /// in tests, access will call to `XCTFail` when invoked, unless explicitly overridden:
+  ///
+  /// ```swift
+  /// // Provision model with overridden dependencies
+  /// let testCenter = NotificationCenter()
+  /// let model = withDependencies {
+  ///   $0.notificationCenter = testCenter
+  /// } operation: {
+  ///   FeatureModel()
+  /// }
+  ///
+  /// // Send notifications and make assertions with model...
+  /// ```
+  public var notificationCenter: NotificationCenter {
+    get { self[NotificationCenterKey.self] }
+    set { self[NotificationCenterKey.self] = newValue }
+  }
+
+  private enum NotificationCenterKey: DependencyKey {
+    static let liveValue = NotificationCenter.default
+  }
+}


### PR DESCRIPTION
I followed the example of how access to `TimeZone` was lifted into `DependencyValues`.