### PR TITLE
Deadlock workaround

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -13,11 +13,11 @@ import XCTestDynamicOverlay
 
 #if _runtime(_ObjC)
   extension DispatchQueue {
-    fileprivate static func mainSync<R>(execute block: @Sendable () -> R) -> R {
+    fileprivate static func mainASAP(execute block: @escaping @Sendable () -> Void) {
       if Thread.isMainThread {
         return block()
       } else {
-        return Self.main.sync(execute: block)
+        return Self.main.async(execute: block)
       }
     }
   }
@@ -129,7 +129,7 @@ public struct DependencyValues: Sendable {
   /// that the library manages for you when you use the ``Dependency`` property wrapper.
   public init() {
     #if _runtime(_ObjC)
-      DispatchQueue.mainSync {
+      DispatchQueue.mainASAP {
         guard
           let XCTestObservation = objc_getProtocol("XCTestObservation"),
           let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -687,7 +687,7 @@ final class DependencyValuesTests: XCTestCase {
       _ = date
     }
 
-    Thread.sleep(forTimeInterval: 0.2)
+    Thread.sleep(forTimeInterval: 0.1)
 
     @Dependency(\.date) var date
     _ = date

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -679,6 +679,19 @@ final class DependencyValuesTests: XCTestCase {
       }
     }
   }
+
+  @MainActor
+  func testDeadlock() {
+    DispatchQueue(label: "queue", qos: .utility).async {
+      @Dependency(\.date) var date
+      _ = date
+    }
+
+    Thread.sleep(forTimeInterval: 0.2)
+
+    @Dependency(\.date) var date
+    _ = date
+  }
 }
 
 struct CountInitDependency: TestDependencyKey {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -398,32 +398,30 @@ final class DependencyValuesTests: XCTestCase {
       self.wait(for: [expectation], timeout: 1)
     }
 
-    #if !os(Linux)
-      @MainActor
-      func testEscapingInFeatureModel_InstanceVariablePropagated() {
-        let expectation = self.expectation(description: "escape")
+    @MainActor
+    func testEscapingInFeatureModel_InstanceVariablePropagated() async {
+      let expectation = self.expectation(description: "escape")
 
-        @MainActor
-        class FeatureModel /*: ObservableObject*/ {
-          @Dependency(\.fullDependency) var fullDependency
-          func doSomething(expectation: XCTestExpectation) {
-            DispatchQueue.main.async {
-              XCTAssertEqual(self.fullDependency.value, 42)
-              expectation.fulfill()
-            }
+      @MainActor
+      class FeatureModel /*: ObservableObject*/ {
+        @Dependency(\.fullDependency) var fullDependency
+        func doSomething(expectation: XCTestExpectation) {
+          DispatchQueue.main.async {
+            XCTAssertEqual(self.fullDependency.value, 42)
+            expectation.fulfill()
           }
         }
-
-        let model = withDependencies {
-          $0.fullDependency.value = 42
-        } operation: {
-          FeatureModel()
-        }
-
-        model.doSomething(expectation: expectation)
-        self.wait(for: [expectation], timeout: 1)
       }
-    #endif
+
+      let model = withDependencies {
+        $0.fullDependency.value = 42
+      } operation: {
+        FeatureModel()
+      }
+
+      model.doSomething(expectation: expectation)
+      await fulfillment(of: [expectation], timeout: 1)
+    }
 
     func testEscapingInFeatureModel_NotPropagated() async {
       let expectation = self.expectation(description: "escape")

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -681,13 +681,15 @@ final class DependencyValuesTests: XCTestCase {
   }
 
   @MainActor
-  func testDeadlock() {
+  func testDeadlock() async {
     DispatchQueue(label: "queue", qos: .utility).async {
       @Dependency(\.date) var date
       _ = date
     }
 
-    Thread.sleep(forTimeInterval: 0.1)
+    // Block main thread for 0.1 seconds.
+    let start = Date()
+    while Date().timeIntervalSince(start) < 0.1 {}
 
     @Dependency(\.date) var date
     _ = date

--- a/Tests/DependenciesTests/FireAndForgetTests.swift
+++ b/Tests/DependenciesTests/FireAndForgetTests.swift
@@ -1,12 +1,12 @@
 import Dependencies
 import XCTest
 
-@MainActor
 final class FireAndForgetTests: XCTestCase {
   @Dependency(\.fireAndForget) var fireAndForget
 
   // NB: These tests fail/crash in Wasm.
   #if !os(WASI)
+    @MainActor
     func testTestContext() async throws {
       let didExecute = ActorIsolated(false)
 
@@ -19,6 +19,7 @@ final class FireAndForgetTests: XCTestCase {
       XCTAssertEqual(value, true)
     }
 
+    @MainActor
     func testTestContext_Cancellation() async throws {
       let didExecute = ActorIsolated(false)
 
@@ -36,6 +37,7 @@ final class FireAndForgetTests: XCTestCase {
       XCTAssertEqual(value, true)
     }
 
+    @MainActor
     func testLiveContext() async throws {
       try await withDependencies {
         $0.context = .live
@@ -58,6 +60,7 @@ final class FireAndForgetTests: XCTestCase {
   #endif
 
   #if !os(Linux) && !os(WASI) && !os(Windows)
+    @MainActor
     func testLiveContext_DependencyAccess() async {
       await withDependencies {
         $0.context = .live


### PR DESCRIPTION
Right now we do a `DispatchQueue.main.sync` in order to make sure that the test observer is registered on the main thread. `sync` is always a dangerous operation, and it turns out we can deadlock. It can be reproduced with the following 3 steps:

1. Start background thread/queue and access a dependency after a small amount of time.
2. Before the dependency is accessed block the main thread with some work.
3. After the main thread work is done access another dependency.

This causes a deadlock because the background thread has already entered into a `dispatch_once` to resolve `static var current` but is currently waiting on the main thread to finish its work. And simultaneously the main thread has now also entered the `dispatch_once`, and hence a deadlock.

The fix is perhaps a little risky, but we think it should be ok. We are going to allow adding the test observer in `main.async` if the dependency is first being accessed on a background thread. It seems theoretically possible that the test observer will not be registered by the time the test ends, but we haven't been able to find a situation in which that occurs.