### PR TITLE
Support swift-syntax from 600.0.0-latest

### DIFF
--- a/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "46989693916f56d1186bd59ac15124caef896560",
-        "version" : "1.3.1"
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "5c4a1b9d7c23cd5c08ea50677d8e89080365cb00",
-        "version" : "0.4.0"
+        "revision" : "851c8b6bde2000d8051dc9aca1efee04dcc37411",
+        "version" : "0.4.1"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
+        "version" : "1.16.1"
       }
     },
     {

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -22,7 +22,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.0"),

--- a/Sources/DependenciesMacrosPlugin/Support.swift
+++ b/Sources/DependenciesMacrosPlugin/Support.swift
@@ -1,8 +1,11 @@
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+
+#if !canImport(SwiftSyntax600)
+  import SwiftSyntaxMacroExpansion
+#endif
 
 extension SyntaxStringInterpolation {
   mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
@@ -230,5 +233,15 @@ extension MacroExpansionContext {
 extension Array where Element == String {
   func qualified(_ module: String) -> Self {
     self.flatMap { [$0, "\(module).\($0)"] }
+  }
+}
+
+extension TypeEffectSpecifiersSyntax {
+  var hasThrowsClause: Bool {
+    #if canImport(SwiftSyntax600)
+      throwsClause != nil
+    #else
+      throwsSpecifier != nil
+    #endif
   }
 }


### PR DESCRIPTION
The Xcode 16 beta generates macro projects using these swift-syntax snapshots. Luckily things seem to be backwards compatible, so we can expand our supported range.