### PR TITLE
Remove reference to cleanse

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,6 @@ following projects all build on top of Dependencies:
 There are many other dependency injection libraries in the Swift community. Each has its own set of
 priorities and trade-offs that differ from Dependencies. Here are a few well-known examples:
 
-  * [Cleanse](https://github.com/square/Cleanse)
   * [Factory](https://github.com/hmlongco/Factory)
   * [Needle](https://github.com/uber/needle)
   * [Swinject](https://github.com/Swinject/Swinject)


### PR DESCRIPTION
Cleanse was deprecated by Square on June 13th 2024.

![image](https://github.com/pointfreeco/swift-dependencies/assets/18543934/170631cd-34d3-4941-8efa-d065790e4eff)
