### PR TITLE
add throwing support to WithRandomGenerator

### DIFF
--- a/Sources/Dependencies/DependencyValues/WithRandomNumberGenerator.swift
+++ b/Sources/Dependencies/DependencyValues/WithRandomNumberGenerator.swift
@@ -71,7 +71,9 @@ public final class WithRandomNumberGenerator: @unchecked Sendable {
     self.generator = generator
   }
 
-  public func callAsFunction<R>(_ work: (inout any RandomNumberGenerator & Sendable) -> R) -> R {
-    return work(&self.generator)
+  public func callAsFunction<R>(_ work: (inout any RandomNumberGenerator & Sendable) throws -> R)
+    rethrows -> R
+  {
+    return try work(&self.generator)
   }
 }

--- a/Tests/DependenciesTests/WithRandomNumberGeneratorTests.swift
+++ b/Tests/DependenciesTests/WithRandomNumberGeneratorTests.swift
@@ -22,6 +22,34 @@ final class WithRandomNumberGeneratorDependencyTests: XCTestCase {
       }
     }
   }
+
+  struct ExpectedError: Error {}
+
+  func testWithRandomNumberGeneratorThrowing() throws {
+    try XCTAssertThrowsError(
+      {
+        try withDependencies {
+          $0.withRandomNumberGenerator = .init(LCRNG(seed: 0))
+        } operation: {
+          try self.withRandomNumberGenerator { generator -> Void in
+            // NB: Wasm has different behavior here.
+            #if os(WASI)
+              let sequence = [5, 6, 5, 4, 4]
+            #else
+              let sequence = [1, 3, 6, 3, 2]
+            #endif
+            for expected in sequence {
+              if expected == 6 {
+                throw ExpectedError()
+              }
+              XCTAssertEqual(.random(in: 1...6, using: &generator), expected)
+            }
+
+          }
+        }
+
+      }(), "Expected error should be thrown")
+  }
 }
 
 private struct LCRNG: RandomNumberGenerator {


### PR DESCRIPTION
I was using `WithRandomGenerator` with a function that that can throw and thought this might be a welcome addition for others. 