### PR TITLE
Fix sendability warnings in new Swift 6 toolchains

### DIFF
--- a/Sources/Dependencies/Internal/Deprecations.swift
+++ b/Sources/Dependencies/Internal/Deprecations.swift
@@ -48,7 +48,7 @@ extension AsyncStream {
   public init<S: AsyncSequence & Sendable>(
     _ sequence: S,
     bufferingPolicy limit: Continuation.BufferingPolicy
-  ) where S.Element == Element {
+  ) where S.Element == Element, S.Element: Sendable {
     self.init(bufferingPolicy: limit) { (continuation: Continuation) in
       let task = Task {
         do {
@@ -77,7 +77,7 @@ extension AsyncThrowingStream where Failure == Error {
   public init<S: AsyncSequence & Sendable>(
     _ sequence: S,
     bufferingPolicy limit: Continuation.BufferingPolicy
-  ) where S.Element == Element {
+  ) where S.Element == Element, S.Element: Sendable {
     self.init(bufferingPolicy: limit) { (continuation: Continuation) in
       let task = Task {
         do {


### PR DESCRIPTION
In Xcode 16 Beta 3 (and also the latest Swift 6 toolchain), there are new data race errors that cause this library to not compile with strict checking enabled:

```
 54 |         do {
 55 |           for try await element in sequence {
 56 |             continuation.yield(element)
    |                          |- error: sending 'element' risks causing data races
    |                          |- note: 'element' used after being passed as a 'sending' parameter; Later uses could race
    |                          `- note: access can happen concurrently
 57 |           }
 58 |           continuation.finish()

/Users/hal/Developer/swift-dependencies/Sources/Dependencies/Internal/Deprecations.swift:85:26: error: sending 'element' risks causing data races
 83 |         do {
 84 |           for try await element in sequence {
 85 |             continuation.yield(element)
    |                          |- error: sending 'element' risks causing data races
    |                          |- note: 'element' used after being passed as a 'sending' parameter; Later uses could race
    |                          `- note: access can happen concurrently
 86 |           }
 87 |           continuation.finish()
```

Adding a `Sendable` constraint for `Element` seems to silence the errors.