### PR TITLE
Add XCTestDynamicOverlay dependency to DependenciesMacros target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
       dependencies: [
         "DependenciesMacrosPlugin",
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .macro(


### PR DESCRIPTION
In order to avoid `No such module 'XCTestDynamicOverlay'` compiler error from "DependenciesMacros/Internal/Exports.swift".