### PR TITLE
Swift 6 boundary issue fix

### DIFF
--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -483,7 +483,7 @@ private func isSetting<R>(
   private func isSetting<R>(
     _ value: Bool,
     isolation: isolated (any Actor)? = #isolation,
-    operation: () async throws -> R
+    operation: () async throws -> sending R
   ) async rethrows -> R {
     #if DEBUG
       try await DependencyValues.$isSetting.withValue(value, operation: operation)


### PR DESCRIPTION
There's currently an error in release builds related to isolation of `operation`:

```481 | #if swift(>=6)
482 |   @_transparent
483 |   private func isSetting<R>(
    |                          `- note: consider making generic parameter 'R' conform to the 'Sendable' protocol
484 |     _ value: Bool,
485 |     isolation: isolated (any Actor)? = #isolation,
    :
489 |       try await DependencyValues.$isSetting.withValue(value, operation: operation)
490 |     #else
491 |       try await operation()
    |                 `- error: non-sendable type 'R' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary
492 |     #endif
493 |   }
```

I believe the correct fix for this is marking `operation` with the `sending` keyword. Here's the Swift proposal for that keyword, maybe someone who better understands concurrency should confirm that my understanding is correct: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md

Fixes #255 