### PR TITLE
Turn off Swift 6 mode.

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -68,8 +68,8 @@ let package = Package(
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
       ]
     ),
-  ],
-  swiftLanguageVersions: [.v6]
+  ]
+  //, swiftLanguageMode: [.v6]
 )
 
 #if !os(macOS) && !os(WASI)
@@ -104,3 +104,10 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   )
 #endif
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+}


### PR DESCRIPTION
While the library compiles just fine with no warnings in full Swift 6 mode, it has become annoying to keep up with the small changes introduced with each Xcode beta. So, we are turning of Swift 6 mode for now, and we will just enable it locally whenever we need to check for Swift 6 compatibility.