### PR TITLE
Turn back on Swift 6 mode.

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -68,8 +68,8 @@ let package = Package(
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
       ]
     ),
-  ]
-  //, swiftLanguageMode: [.v6]
+  ],
+  swiftLanguageVersions: [.v6]
 )
 
 #if !os(macOS) && !os(WASI)


### PR DESCRIPTION
We temporarily turned off Swift 6 mode because so much was changing with the Xcode betas, but now that the official release of Xcode 16 is out we can turn it back on.