### PR TITLE
Add `#Preview` and `@Test` traits for overriding dependencies

### DIFF
--- a/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Dependencies.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "3fcc3f21695ad5bb889a024b1b046d61bebb1ef3",
-        "version" : "1.3.0"
+        "revision" : "bc2a151366f2cd0e347274544933bc2acb00c9fe",
+        "version" : "1.4.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.4"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -20,12 +20,16 @@ let package = Package(
       name: "DependenciesMacros",
       targets: ["DependenciesMacros"]
     ),
+    .library(
+      name: "DependenciesTestSupport",
+      targets: ["DependenciesTestSupport"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.4"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.3.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [
@@ -45,11 +49,18 @@ let package = Package(
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
+    .target(
+      name: "DependenciesTestSupport",
+      dependencies: [
+        "Dependencies",
+      ]
+    ),
     .testTarget(
       name: "DependenciesTests",
       dependencies: [
         "Dependencies",
         "DependenciesMacros",
+        "DependenciesTestSupport",
         .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
       ]
     ),

--- a/Sources/Dependencies/Documentation.docc/Articles/LivePreviewTest.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/LivePreviewTest.md
@@ -37,6 +37,8 @@ be written to disk, which will bleed into other tests, and more.
 Using live dependencies in tests are so problematic that the library will cause a test failure
 if you ever interact with a live dependency while tests are running:
 
+<!-- TODO: @Test -->
+
 ```swift
 func testFeature() async throws {
   let model = FeatureModel()

--- a/Sources/Dependencies/Traits/PreviewTrait.swift
+++ b/Sources/Dependencies/Traits/PreviewTrait.swift
@@ -1,0 +1,24 @@
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
+  extension PreviewTrait where T == Preview.ViewTraits {
+    public static func dependency<Value: Sendable>(
+      _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
+      _ value: Value
+    ) -> PreviewTrait {
+      .dependencies { $0[keyPath: keyPath] = value }
+    }
+
+    public static func dependencies(
+      _ operation: @Sendable (inout DependencyValues) -> Void
+    ) -> PreviewTrait {
+      previewValues.withValue {
+        operation(&$0)
+      }
+      return PreviewTrait()
+    }
+  }
+
+  let previewValues = LockIsolated(DependencyValues())
+#endif

--- a/Sources/Dependencies/Traits/TestTrait.swift
+++ b/Sources/Dependencies/Traits/TestTrait.swift
@@ -1,0 +1,9 @@
+public struct _DependenciesTrait: Sendable {
+  package let operation: @Sendable (inout DependencyValues) -> Void
+
+  package init(_ operation: @escaping @Sendable (inout DependencyValues) -> Void) {
+    self.operation = operation
+  }
+
+  package static let all = LockIsolated<[AnyHashable: DependencyValues]>([:])
+}

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -1,0 +1,27 @@
+#if canImport(Testing)
+  import Dependencies
+  import Testing
+
+  extension Trait where Self == _DependenciesTrait {
+    public static func dependency<Value: Sendable>(
+      _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
+      _ value: Value
+    ) -> Self {
+      Self { $0[keyPath: keyPath] = value }
+    }
+
+    public static func dependencies(
+      _ operation: @escaping @Sendable (inout DependencyValues) -> Void
+    ) -> Self {
+      Self(operation)
+    }
+  }
+
+  extension _DependenciesTrait: SuiteTrait, TestTrait {
+    public var isRecursive: Bool { true }
+
+    public func prepare(for test: Test) async throws {
+      Self.all.withValue { self.operation(&$0[test.id, default: DependencyValues()]) }
+    }
+  }
+#endif

--- a/Tests/DependenciesTests/SwiftTestingTests.swift
+++ b/Tests/DependenciesTests/SwiftTestingTests.swift
@@ -1,5 +1,6 @@
 #if canImport(Testing)
   import Dependencies
+  import DependenciesTestSupport
   import Foundation
   import Testing
 

--- a/Tests/DependenciesTests/SwiftTestingTests.swift
+++ b/Tests/DependenciesTests/SwiftTestingTests.swift
@@ -1,5 +1,6 @@
 #if canImport(Testing)
   import Dependencies
+  import Foundation
   import Testing
 
   struct SwiftTestingTests {
@@ -44,6 +45,37 @@
       #else
         #expect(value == 1)
       #endif
+    }
+
+    @Test(.dependency(\.date.now, Date(timeIntervalSinceReferenceDate: 0)))
+    func trait() {
+      @Dependency(\.date.now) var now
+      #expect(now == Date(timeIntervalSinceReferenceDate: 0))
+    }
+
+    @Suite(.dependency(\.date.now, Date(timeIntervalSinceReferenceDate: 0)))
+    struct InnerSuite {
+      @Test
+      func traitInherited() {
+        @Dependency(\.date.now) var now
+        #expect(now == Date(timeIntervalSinceReferenceDate: 0))
+      }
+
+      @Test(.dependency(\.date.now, Date(timeIntervalSinceReferenceDate: 1)))
+      func traitOverridden() {
+        @Dependency(\.date.now) var now
+        #expect(now == Date(timeIntervalSinceReferenceDate: 1))
+      }
+
+      @Test(.dependency(\.date.now, Date(timeIntervalSinceReferenceDate: 1)))
+      func traitOverriddenWithDependencies() {
+        withDependencies {
+          $0.date.now = Date(timeIntervalSinceReferenceDate: 2)
+        } operation: {
+          @Dependency(\.date.now) var now
+          #expect(now == Date(timeIntervalSinceReferenceDate: 2))
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR introduces new traits for overriding dependencies.

In previews:

```swift
#Preview(
  .dependencies {
    $0.apiClient = .failsOnSignUp
    $0.date.now = Date(timeIntervalSince1970: 1234567890)
    $0.continuousClock = .immediate
  }
) {
  // The 'apiClient', 'date' and 'continuousClock' dependencies
  // are all overridden in this preview.
  SignUpView(
	  model: SignUpModel()
  )
}
```

In tests:

```swift
import DependenciesTestSupport

@Test(
  .dependency(\.apiClient, .failsOnSignUp),
  .dependency(\.date.now, Date(timeIntervalSince1970: 1234567890)),
  .dependency(\.continuousClock, .immediate)  
)
func feature() {
  let model = SignUpModel()
  // The 'apiClient', 'date' and 'continuousClock' dependencies
  // are all overridden in this scope.
}
```