### PR TITLE
Remove experimental feature because upcoming feature 'StrictConcurrency' is already enabled as of Swift version 6

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -115,10 +115,3 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   )
 #endif
-
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings?.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
-  ])
-}


### PR DESCRIPTION
## WHY

- `Package@swift-6.0.swift` enables `swiftLanguageVersions: [.v6]`
- Swift6 mode enables StrictConcurrency, so this option is not necessary.
    - Sometimes this option triggers error (ref: https://github.com/shimastripe/InAppPurchaseViewer/actions/runs/10870715912/job/30163657735 )

## WHAT

- remove `.enableExperimentalFeature("StrictConcurrency")`