### PR TITLE
Link to `IssueReportingTestSupport`

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -53,6 +53,7 @@ let package = Package(
       name: "DependenciesTestSupport",
       dependencies: [
         "Dependencies",
+        .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
Without explicit linking here, the test IDs will not match.