### PR TITLE
Restore Library Evolution support for Xcode 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   macos:
     name: macOS
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       matrix:
         config: ['debug', 'release']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   macos:
     name: macOS
-    runs-on: macos-14
+    runs-on: macos-latest
     strategy:
       matrix:
         config: ['debug', 'release']
@@ -31,6 +31,8 @@ jobs:
         run: make test-swift
       - name: Build platforms ${{ matrix.config }}
         run: CONFIG=${{ matrix.config }} make build-all-platforms
+      - name: Build for library evolution
+        run: make build-for-library-evolution
 
   ubuntu:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ build-for-library-evolution:
 		-Xswiftc -emit-module-interface \
 		-Xswiftc -enable-library-evolution
 
+	swift build \
+		-c release \
+		--target DependenciesMacros \
+		-Xswiftc -emit-module-interface \
+		-Xswiftc -enable-library-evolution \
+		-Xswiftc -DRESILIENT_LIBRARIES # Required to build swift-syntax; see https://github.com/swiftlang/swift-syntax/pull/2540
+
 build-for-static-stdlib-docker:
 	@docker run \
 		-v "$(PWD):$(PWD)" \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b70d24a284d4a26856cfef0d2ef69b0e2326a2fa8a91e22c08eba0cad0f59bcd",
+  "originHash" : "ac879199bc109c96e02f389573ce5b101fa5c8a274b809fc57dba0d4736f5b6f",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "bc2a151366f2cd0e347274544933bc2acb00c9fe",
-        "version" : "1.4.0"
+        "revision" : "27d767d643fa2cf083d0a73d74fa84cacb53e85c",
+        "version" : "1.4.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
-        "version" : "600.0.0-prerelease-2024-09-04"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     },
     {

--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -120,6 +120,7 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
           if accessors.contains(where: { $0.accessorSpecifier.tokenKind == .keyword(.get) }) {
             continue
           }
+        @unknown default: return []
         }
       }
 


### PR DESCRIPTION
- Builds for Library Evolution support, and patches a small issue in this repository causing an issue for us, i.e. - 

![image](https://github.com/user-attachments/assets/4db592c1-cdf7-4af4-b6c7-9687194f0998)

- Adds Library Evolution support target replicating the issue to CI

**Additional Notes**
I noticed [this comment](https://github.com/pointfreeco/swift-dependencies/pull/277#discussion_r1761462481); we're needing Library Evolution support for some beta apps we're working on using `swift-dependencies`. 

Happy to assist with the maintenance, as far as it useful ! 