### PR TITLE
Update Package@swift-6.0.swift

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -81,7 +81,7 @@ let package = Package(
       ]
     ),
   ],
-  swiftLanguageVersions: [.v6]
+  swiftLanguageModes: [.v6]
 )
 
 #if !os(macOS) && !os(WASI)


### PR DESCRIPTION
Fixes downstream warnings:

```
'swift-dependencies': /__w/SwiftPackageIndex-Server/SwiftPackageIndex-Server/.build/checkouts/swift-dependencies/Package@swift-6.0.swift:6:15: warning: 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is deprecated: replaced by 'init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)'
```