### PR TITLE
Override Test ID to ensure trait dependencies are cached

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac879199bc109c96e02f389573ce5b101fa5c8a274b809fc57dba0d4736f5b6f",
+  "originHash" : "dc8209f1497546c820fac828af8d595b6882cb88310f412367280d8cde593506",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -76,10 +76,10 @@
     {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "location" : "https://github.com/jflan-dd/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "27d767d643fa2cf083d0a73d74fa84cacb53e85c",
-        "version" : "1.4.1"
+        "branch" : "jflan/override-test-id",
+        "revision" : "09a97f20368a8c47b1fd86c4be9beb49585414ea"
       }
     }
   ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -29,7 +29,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.4"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.0"),
+    .package(url: "https://github.com/jflan-dd/xctest-dynamic-overlay", branch: "jflan/override-test-id"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -362,6 +362,31 @@ private let defaultContext: DependencyContext = {
 }()
 
 @_spi(Internals)
+public struct TestID: @unchecked Sendable {
+  @TaskLocal private static var override: Self?
+  
+  public let value: AnyHashable
+  
+  public init(_ value: AnyHashable) {
+    self.value = value
+  }
+  
+  public static func withCurrent<R>(_ testID: AnyHashable, perform body: () async throws -> R) async rethrows -> R {
+    try await Self.$override.withValue(TestID(testID), operation: body)
+  }
+  
+  public static var current: Self? {
+    if let value = override { return value }
+    
+    if case let .swiftTesting(.some(testing)) = TestContext.current {
+      return .init(testing.test.id.rawValue)
+    }
+    
+    return nil
+  }
+}
+
+@_spi(Internals)
 public final class CachedValues: @unchecked Sendable {
   @TaskLocal static var isAccessingCachedDependencies = false
 
@@ -373,10 +398,10 @@ public final class CachedValues: @unchecked Sendable {
     init(id: TypeIdentifier, context: DependencyContext) {
       self.id = id
       self.context = context
-      switch TestContext.current {
-      case let .swiftTesting(.some(testing)):
-        self.testIdentifier = testing.test.id
-      default:
+      if let testID = TestID.current {
+        // unsafeBitCast used because current version of xctest-dynamic-overlay does not expose init
+        self.testIdentifier = unsafeBitCast(testID, to: TestContext.Testing.Test.ID.self)
+      } else {
         self.testIdentifier = nil
       }
     }
@@ -415,8 +440,8 @@ public final class CachedValues: @unchecked Sendable {
           }
         case .test:
           if !CachedValues.isAccessingCachedDependencies,
-            case let .swiftTesting(.some(testing)) = TestContext.current,
-            let testValues = testValuesByTestID.withValue({ $0[testing.test.id.rawValue] })
+            let testID = TestID.current,
+            let testValues = testValuesByTestID.withValue({ $0[testID.value] })
           {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
               testValues[key]

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -1,5 +1,5 @@
 #if canImport(Testing)
-  import Dependencies
+  @_spi(Internals) import Dependencies
   import Testing
 
   extension Trait where Self == _DependenciesTrait {
@@ -59,8 +59,10 @@
     public var isRecursive: Bool { true }
 
     public func prepare(for test: Test) async throws {
-      testValuesByTestID.withValue {
-        self.updateValues(&$0[test.id, default: DependencyValues(context: .test)])
+      await TestID.withCurrent(test.id) {
+        testValuesByTestID.withValue { values in
+          self.updateValues(&values[test.id, default: DependencyValues(context: .test)])
+        }
       }
     }
   }

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -1,5 +1,5 @@
 #if canImport(Testing)
-  @_spi(Internals) import Dependencies
+  import Dependencies
   import Testing
 
   extension Trait where Self == _DependenciesTrait {
@@ -59,7 +59,7 @@
     public var isRecursive: Bool { true }
 
     public func prepare(for test: Test) async throws {
-      await TestID.withCurrent(test.id) {
+      TestContext.withTestID(test.id) {
         testValuesByTestID.withValue { values in
           self.updateValues(&values[test.id, default: DependencyValues(context: .test)])
         }


### PR DESCRIPTION
I ran into an issue where reference typed dependencies weren't correctly cached if they were updated in-place rather than being fully overridden.

The root cause of this seems to be that `Test.current` isn't set during `prepare(for test: Test)` and as a result the `CacheKey.testIdentifier` was `nil` during dependency setup.

~~This PR creates an internal `TestID` struct that can be explicitly overridden during dependency prep, but perhaps there's a more elegant solution that could be implemented in `xctest-dymaic-overlay` directly.~~

This PR is dependent on https://github.com/pointfreeco/swift-issue-reporting/pull/137