### PR TITLE
Relax preview traits sendability.

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -485,7 +485,11 @@ public final class CachedValues: @unchecked Sendable {
         case .preview:
           if !CachedValues.isAccessingCachedDependencies {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
-              previewValues.withValue { $0[key] }
+              #if compiler(>=6)
+                return previewValues[key]
+              #else
+                return Key.previewValue
+              #endif
             }
           } else {
             value = Key.previewValue

--- a/Sources/Dependencies/Traits/PreviewTrait.swift
+++ b/Sources/Dependencies/Traits/PreviewTrait.swift
@@ -19,7 +19,7 @@
     /// - Parameters:
     ///   - keyPath: A key path to a dependency value.
     ///   - value: A dependency value to override for the lifetime of the preview.
-    public static func dependency<Value: Sendable>(
+    public static func dependency<Value>(
       _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
       _ value: Value
     ) -> PreviewTrait {
@@ -45,14 +45,12 @@
     /// - Parameter updateValuesForPreview: A closure for updating the current dependency values for
     ///   the lifetime of the preview.
     public static func dependencies(
-      _ updateValuesForPreview: @Sendable (inout DependencyValues) -> Void
+      _ updateValuesForPreview: (inout DependencyValues) -> Void
     ) -> PreviewTrait {
-      previewValues.withValue {
-        updateValuesForPreview(&$0)
-      }
+      updateValuesForPreview(&previewValues)
       return PreviewTrait()
     }
   }
-#endif
 
-let previewValues = LockIsolated(DependencyValues(context: .preview))
+  nonisolated(unsafe) var previewValues = DependencyValues(context: .preview)
+#endif


### PR DESCRIPTION
Currently there are some sendability requirements for the `.dependency` preview trait, and that's only necessary because we store preview values in a `LockIsolated`. However, it seems that preview traits are only ever executed from the main queue, and so isolation shouldn't be necessary. So we are going to relax this until we find out that traits can be executed on non-main threads.