### PR TITLE
Fix build failure on Linux

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -545,7 +545,11 @@ public final class CachedValues: @unchecked Sendable {
         case .preview:
           if !CachedValues.isAccessingCachedDependencies {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
-              return Key.previewValue
+              #if canImport(SwiftUI) && compiler(>=6)
+                return previewValues[key]
+              #else
+                return Key.previewValue
+              #endif
             }
           } else {
             value = Key.previewValue

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -545,11 +545,7 @@ public final class CachedValues: @unchecked Sendable {
         case .preview:
           if !CachedValues.isAccessingCachedDependencies {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
-              #if compiler(>=6)
-                return previewValues[key]
-              #else
-                return Key.previewValue
-              #endif
+              return Key.previewValue
             }
           } else {
             value = Key.previewValue


### PR DESCRIPTION
This fixes the build error reported in #302 , although I'm not sure this is the right fix.

- Tests on macOS/Swift 6 pass
- Tests fail to compile on Linux/Swift 6 but it is _not_ a regression. It also fails on Linux/Swift 6 for 1.4.1:

```
/host/Tests/DependenciesTests/DependencyValuesTests.swift:462:13: error: sending main actor-isolated value of type 'DependencyValuesTests' with later accesses to nonisolated context risks causing data races
 460 | 
 461 |       model.doSomething(expectation: expectation)
 462 |       await fulfillment(of: [expectation], timeout: 1)
     |             `- error: sending main actor-isolated value of type 'DependencyValuesTests' with later accesses to nonisolated context risks causing data races
 463 |     }
```

Tests compile if I comment out this test `testEscapingInFeatureModel_InstanceVariablePropagated`.

Tests then mostly pass but there's a crash in the end. I'm not sure if it's due to "Swift Testing" and some cleanup or if it's a test that's crashing:

```
◇ Test run started.
↳ Testing Library Version: 6.0.2 (cd448bbe5cc989d)
◇ Suite SwiftTestingTests started.
◇ Suite InnerSuite started.
◇ Test parameterizedCachePollution_ResetDependencies(_:) started.
◇ Test parameterizedCachePollution(_:) started.
◇ Test cachePollution2() started.
◇ Test trait() started.
◇ Test cachePollution1() started.
◇ Passing 1 argument argument → 5 to parameterizedCachePollution_ResetDependencies(_:)
◇ Passing 1 argument argument → 4 to parameterizedCachePollution_ResetDependencies(_:)
◇ Passing 1 argument argument → 2 to parameterizedCachePollution_ResetDependencies(_:)
◇ Passing 1 argument argument → 1 to parameterizedCachePollution_ResetDependencies(_:)
◇ Passing 1 argument argument → 1 to parameterizedCachePollution(_:)
◇ Passing 1 argument argument → 3 to parameterizedCachePollution_ResetDependencies(_:)
◇ Test traitOverriddenWithDependencies() started.
◇ Test traitOverridden() started.
◇ Test traitInherited() started.
✔ Test cachePollution2() passed after 0.001 seconds.
✔ Test parameterizedCachePollution_ResetDependencies(_:) passed after 0.001 seconds.
✘ Test traitInherited() recorded an issue at Date.swift:43:18: Issue recorded
↳ Unimplemented: @Dependency(\.date)
✔ Test cachePollution1() passed after 0.001 seconds.

*** Signal 11: Backtracing from 0x4... done ***

*** Program crashed: Bad pointer dereference at 0x0000000000000004 ***

Thread 0 crashed:

0      0x0000000000000004
1 [ra] 0x0000ffffbae60401

Thread 1:

0  0x0000000000006763


Registers:

 x0 0x0000000000000000  0
 x1 0x0000ffffaf40c1a8  00 00 c0 02 00 00 00 00 58 00 15 ea aa aa 00 00  ··À·····X··êªª··
 x2 0x00ffffffffffffff  72057594037927935
 x3 0x001c5bdcc85347dc  7982303159732188
 x4 0x00000000000e3084  929924
 x5 0x0000ffffa4003560  f3 75 fa 5b f0 ff 00 00 56 49 7d a8 0a a0 e6 de  óuú[ðÿ··VI}¨· æÞ
 x6 0xdee6a00aa87d4956  16061701088700352854
 x7 0x0000000100000003  4294967299
 x8 0x0000ffffbb49d000  00 00 00 00 00 00 00 00 05 00 00 00 00 00 00 00  ················
 x9 0x0000ffffbb49d000  00 00 00 00 00 00 00 00 05 00 00 00 00 00 00 00  ················
x10 0x0000000067331aa1  1731402401
x11 0x0000000000000000  0
x12 0x000000007fffffff  2147483647
x13 0x00000000000e3084  929924
x14 0x0000064708db4287  6902161031815
x15 0x0000000029aaaa46  699050566
x16 0x0000000000000018  24
x17 0x0000064708daa2db  6902160990939
x18 0x0000000000000035  53
x19 0x0000ffffaf40d548  00 00 00 00 00 00 00 00 00 d7 40 af ff ff 00 00  ·········×@¯ÿÿ··
x20 0x00000000605dab24  1616751396
x21 0x0000aaaae82229c0  ff 43 01 d1 fd 7b 03 a9 f4 23 00 f9 fd c3 00 91  ÿC·Ñý{·©ô#·ùýÃ··
x22 0x0000aaaaea150058  a0 19 22 e8 aa aa 00 00 e4 19 22 e8 aa aa 00 00   ·"èªª··ä·"èªª··
x23 0x0000000002c00000  46137344
x24 0x0000ffffaf40d580  01 00 00 00 00 00 00 00 b0 7f 47 bb ff ff 00 00  ········°·G»ÿÿ··
x25 0x0000ffffaf40d560  00 d7 40 af ff ff 00 00 6c 09 9b ba ff ff 00 00  ·×@¯ÿÿ··l··ºÿÿ··
x26 0x0000ffffa40014d8  25 00 00 00 00 00 00 00 02 00 00 00 0f 00 00 00  %···············
x27 0x0000000000000010  16
x28 0x0000ffffbae5ffe0  60 be 00 b0 ff ff 00 00 02 00 00 00 00 00 00 00  `¾·°ÿÿ··········
 fp 0x0000ffff88003df8  56 49 7d a8 0a a0 e6 de 01 04 e6 ba ff ff 00 00  VI}¨· æÞ··æºÿÿ··
 lr 0x0000000000000004  4
 sp 0x0000ffffaf40d430  40 5f 02 a4 ff ff 00 00 a0 ff e5 ba ff ff 00 00  @_·¤ÿÿ·· ÿåºÿÿ··
 pc 0x0000000000000004  4


Images (54 omitted):



Backtrace took 0.00s

error: Exited with unexpected signal code 11
```

Hope this helps, just wanted to leave some info!

We'll pin to 1.4.1 for now, although I'm a bit worried that our platform Linux/Swift 6 isn't passing tests for 1.4.1, either 😬