### PR TITLE
Fix state sharing bug in `.dependency(_:_:)` trait

### DIFF
--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -43,10 +43,10 @@
     ///   - value: A dependency value to override for the test.
     public static func dependency<Value>(
       _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
-      _ value: sending Value
+      _ value: @escaping @Sendable @autoclosure () -> Value
     ) -> Self {
-      Self { [uncheckedValue = UncheckedSendable(value)] in
-        $0[keyPath: keyPath] = uncheckedValue.wrappedValue
+      Self {
+        $0[keyPath: keyPath] = value()
       }
     }
 
@@ -79,9 +79,9 @@
     ///   - keyPath: A key path to a dependency value.
     ///   - value: A dependency value to override for the test.
     public static func dependency<Value: TestDependencyKey>(
-      _ value: Value
+      _ value: @escaping @Sendable @autoclosure () -> Value
     ) -> Self where Value == Value.Value {
-      Self { $0[Value.self] = value }
+      Self { $0[Value.self] = value() }
     }
 
     /// A trait that overrides a test's or suite's dependencies.


### PR DESCRIPTION
When the `.dependency(_:_:)` function is used with a reference type to override the dependency for a test suite, tests can inadvertently share state because the same instance is used for each test:
```swift
@Suite(.serialized, .dependency(\.classClient, ClassClient()))
struct Example {
  @Test
  func test1() {
    @Dependency(\.classClient) var client
    client.count += 1
    #expect(client.count == 1)
  }

  @Test
  func test2() {
    @Dependency(\.classClient) var client
    client.count += 1
    #expect(client.count == 1) // 🛑 Expectation failed: (client.count → 2) == 1
  }
}
```

To fix this, this PR changes the `value` argument to be an `@autoclosure` so that a new instance can be created for each test. Let me know if there's an alternate solution that would be better!