### PR TITLE
Fix prepareDependencies when using TestDependencyKey.

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -480,7 +480,7 @@ public final class CachedValues: @unchecked Sendable {
         if
           context == .live,
           !DependencyValues.isSetting,
-          (cached[cacheKey] == nil || cached[cacheKey]?.preparationID == nil),
+          !(cached[cacheKey] != nil && cached[cacheKey]?.preparationID != nil),
           !(key is any DependencyKey.Type)
         {
           reportIssue(

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -477,7 +477,12 @@ public final class CachedValues: @unchecked Sendable {
     return withIssueContext(fileID: fileID, filePath: filePath, line: line, column: column) {
       let cacheKey = CacheKey(id: TypeIdentifier(key), context: context)
       #if DEBUG
-        if context == .live, !DependencyValues.isSetting, !(key is any DependencyKey.Type) {
+        if
+          context == .live,
+          !DependencyValues.isSetting,
+          (cached[cacheKey] == nil || cached[cacheKey]?.preparationID == nil),
+          !(key is any DependencyKey.Type)
+        {
           reportIssue(
             {
               var dependencyDescription = ""

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -12,8 +12,10 @@ public func prepareDependencies(
   _ updateValues: (inout DependencyValues) throws -> Void
 ) rethrows {
   var dependencies = DependencyValues._current
-  try DependencyValues.$preparationID.withValue(UUID()) {
-    try updateValues(&dependencies)
+  try DependencyValues.$isSetting.withValue(true) {
+    try DependencyValues.$preparationID.withValue(UUID()) {
+      try updateValues(&dependencies)
+    }
   }
 }
 

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -12,10 +12,8 @@ public func prepareDependencies(
   _ updateValues: (inout DependencyValues) throws -> Void
 ) rethrows {
   var dependencies = DependencyValues._current
-  try DependencyValues.$isSetting.withValue(true) {
-    try DependencyValues.$preparationID.withValue(UUID()) {
-      try updateValues(&dependencies)
-    }
+  try DependencyValues.$preparationID.withValue(UUID()) {
+    try updateValues(&dependencies)
   }
 }
 

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -736,6 +736,18 @@ final class DependencyValuesTests: XCTestCase {
     XCTAssertEqual(now, Date(timeIntervalSinceReferenceDate: 0))
   }
 
+  func testPrepareDependencies_setsDependency_LiveContext() {
+    withDependencies {
+      $0.context = .live
+    } operation: {
+      prepareDependencies {
+        $0[ClientWithEndpoint.self] = ClientWithEndpoint(get: { 1729 })
+      }
+      @Dependency(ClientWithEndpoint.self) var client
+      XCTAssertEqual(client.get(), 1729)
+    }
+  }
+
   #if DEBUG && !os(Linux) && !os(WASI) && !os(Windows)
     func testPrepareDependencies_MultiplePreparesWithNoAccessBetween() {
       prepareDependencies {


### PR DESCRIPTION
Currently `prepareDependencies` does not work for dependencies that only have a `TestDependencyKey` conformance. This fixes that.