### PR TITLE
Don't cache preview app entry point dependencies

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -269,7 +269,7 @@ public struct DependencyValues: Sendable {
     set {
       if DependencyValues.isPreparing {
         if context == .preview, Thread.isPreviewAppEntryPoint {
-          reportIssue("Ignoring dependencies prepared in app entry point")
+          reportIssue("Ignoring dependencies prepared in preview app entry point")
           return
         }
         let cacheKey = CachedValues.CacheKey(id: TypeIdentifier(key), context: context)

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -268,6 +268,10 @@ public struct DependencyValues: Sendable {
     }
     set {
       if DependencyValues.isPreparing {
+        if context == .preview, Thread.isPreviewAppEntryPoint {
+          reportIssue("Ignoring dependencies prepared in app entry point")
+          return
+        }
         let cacheKey = CachedValues.CacheKey(id: TypeIdentifier(key), context: context)
         guard !cachedValues.cached.keys.contains(cacheKey) else {
           if cachedValues.cached[cacheKey]?.preparationID != DependencyValues.preparationID {
@@ -547,6 +551,9 @@ public final class CachedValues: @unchecked Sendable {
         case .live:
           value = (key as? any DependencyKey.Type)?.liveValue as? Key.Value
         case .preview:
+          if Thread.isPreviewAppEntryPoint {
+            return Key.previewValue
+          }
           if !CachedValues.isAccessingCachedDependencies {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
               #if canImport(SwiftUI) && compiler(>=6)

--- a/Sources/Dependencies/Internal/AppEntryPoint.swift
+++ b/Sources/Dependencies/Internal/AppEntryPoint.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Thread {
+  public static var isPreviewAppEntryPoint: Bool {
+    containsSymbol("$s7SwiftUI3AppPAAE4mainyyFZ")
+      && !containsSymbol("$s7SwiftUI6runAppys5NeverOxAA0D0RzlF")
+  }
+
+  static func containsSymbol(_ symbol: String) -> Bool {
+    func frameContainsSymbol(_ frame: String) -> Bool {
+      frame.utf8
+        .reversed()
+        .drop(while: { (48...57).contains($0) })
+        .dropFirst(3)
+        .starts(with: symbol.utf8.reversed())
+    }
+    return callStackSymbols
+      .reversed()
+      .contains(where: frameContainsSymbol)
+  }
+}

--- a/Sources/Dependencies/Internal/AppEntryPoint.swift
+++ b/Sources/Dependencies/Internal/AppEntryPoint.swift
@@ -2,20 +2,29 @@ import Foundation
 
 extension Thread {
   public static var isPreviewAppEntryPoint: Bool {
-    containsSymbol("$s7SwiftUI3AppPAAE4mainyyFZ")
-      && !containsSymbol("$s7SwiftUI6runAppys5NeverOxAA0D0RzlF")
-  }
+    guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    else { return false }
 
-  static func containsSymbol(_ symbol: String) -> Bool {
-    func frameContainsSymbol(_ frame: String) -> Bool {
-      frame.utf8
-        .reversed()
-        .drop(while: { (48...57).contains($0) })
-        .dropFirst(3)
-        .starts(with: symbol.utf8.reversed())
+    var isPreviewAppEntryPoint = false
+    for frame in callStackSymbols.reversed() {
+      if !isPreviewAppEntryPoint, frame.containsSymbol("$s7SwiftUI3AppPAAE4mainyyFZ") {
+        isPreviewAppEntryPoint = true
+      } else if isPreviewAppEntryPoint,
+        frame.containsSymbol("$s7SwiftUI6runAppys5NeverOxAA0D0RzlF")
+      {
+        isPreviewAppEntryPoint = false
+      }
     }
-    return callStackSymbols
+    return isPreviewAppEntryPoint
+  }
+}
+
+extension String {
+  fileprivate func containsSymbol(_ symbol: String) -> Bool {
+    utf8
       .reversed()
-      .contains(where: frameContainsSymbol)
+      .drop(while: { (48...57).contains($0) })
+      .dropFirst(3)
+      .starts(with: symbol.utf8.reversed())
   }
 }

--- a/Sources/Dependencies/Internal/AppEntryPoint.swift
+++ b/Sources/Dependencies/Internal/AppEntryPoint.swift
@@ -12,7 +12,7 @@ extension Thread {
       } else if isPreviewAppEntryPoint,
         frame.containsSymbol("$s7SwiftUI6runAppys5NeverOxAA0D0RzlF")
       {
-        isPreviewAppEntryPoint = false
+        return false
       }
     }
     return isPreviewAppEntryPoint


### PR DESCRIPTION
We have a longstanding gotcha where we tell folks to avoid instantiating their root model on their app entry point because any dependencies on the root model may negatively affect any preview in their application.

This PR detects when a dependency is accessed in a SwiftUI preview app entry point and prevents it from influencing the cache using the call stack symbols available. While this isn't a silver bullet, and any async work kicked off from the app entry point could still affect things negatively, this should hopefully be mostly an improvement on the status quo and maybe we won't have to refer folks to this gotcha as often in the future.