### PR TITLE
Allow `prepareDependencies` to override context

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -235,7 +235,15 @@ public struct DependencyValues: Sendable {
       else {
         let context =
           self.storage[ObjectIdentifier(DependencyContextKey.self)] as? DependencyContext
-          ?? defaultContext
+          ?? self.cachedValues.value(
+            for: DependencyContextKey.self,
+            context: defaultContext,
+            fileID: fileID,
+            filePath: filePath,
+            function: function,
+            line: line,
+            column: column
+          )
 
         switch context {
         case .live, .preview:

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -736,6 +736,16 @@ final class DependencyValuesTests: XCTestCase {
     XCTAssertEqual(now, Date(timeIntervalSinceReferenceDate: 0))
   }
 
+  func testPrepareDependencies_setsLiveContext() {
+    prepareDependencies {
+      $0.context = .live
+    }
+    @Dependency(\.context) var context
+    XCTAssertEqual(context, .live)
+    @Dependency(FullDependency.self) var client
+    XCTAssertEqual(client.value, FullDependency.liveValue.value)
+  }
+
   func testPrepareDependencies_setsDependency_LiveContext() {
     withDependencies {
       $0.context = .live
@@ -841,19 +851,6 @@ final class DependencyValuesTests: XCTestCase {
         }
         XCTAssertNotEqual(date(), Date(timeIntervalSinceReferenceDate: 42))
       }
-    }
-  #endif
-
-  #if DEBUG && !os(Linux) && !os(WASI) && !os(Windows)
-    func testPrepareDependencies_PrepareContext() {
-      prepareDependencies { $0.context = .live }
-
-      XCTTODO(
-        """
-        Currently 'context' cannot be overridden with 'prepareDependencies'.
-        """)
-      @Dependency(\.date) var date
-      _ = date()
     }
   #endif
 


### PR DESCRIPTION
Useful, _e.g._ for `#Preview`s that want to run all dependencies in live mode by default.