### PR TITLE
Fix build of unit tests on Xcode 16

### DIFF
--- a/Tests/DependenciesTests/TestTraitTests.swift
+++ b/Tests/DependenciesTests/TestTraitTests.swift
@@ -8,6 +8,7 @@
   struct TestTraitTests {
     @Dependency(\.uuid) var uuid
 
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     @Test func statefulDependency1() async throws {
       for index in 0...100 {
         #expect(uuid() == UUID(index))
@@ -15,6 +16,7 @@
       }
     }
 
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     @Test func statefulDependency2() async throws {
       for index in 0...100 {
         #expect(uuid() == UUID(index))
@@ -22,6 +24,7 @@
       }
     }
 
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     @Test func statefulDependency3() async throws {
       for index in 0...100 {
         #expect(uuid() == UUID(index))


### PR DESCRIPTION
The unit test file `TestTraitTests.swift` failed to build on Xcode 16:

> ```
> 'sleep(for:tolerance:clock:)' is only available in iOS 16.0 or newer
>
> 'milliseconds' is only available in iOS 16.0 or newer
> ```

Adding the appropriate `@available` markers fixes the build.