### PR TITLE
Enable creating initializers even without endpoints

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -216,10 +216,12 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
       )
       hasEndpoints = hasEndpoints || isEndpoint
     }
-    guard hasEndpoints else { return [] }
     let access = accesses.min().flatMap { $0.token?.with(\.trailingTrivia, .space) }
+    let propertyCandidates = hasEndpoints
+      ? [properties, properties.filter { !$0.isEndpoint }]
+      : [properties.filter { !$0.isEndpoint }]
     // TODO: Don't define initializers if any single endpoint is invalid
-    return [properties, properties.filter { !$0.isEndpoint }].map {
+    return propertyCandidates.map {
       $0.isEmpty
         ? "\(access)init() {}"
         : """


### PR DESCRIPTION
**Motivation**
In our projects we like to group endpoint dependencies in their own @DependencyClient domains and then expose them via a proxy struct that just has the sub dependencies as members. We'd like to just add the @DependencyClient macro to the proxy struct and get the initializer creation for free. 

**Impact**
It's a subtle change to the end of the macro which doesn't early out when there's no endpoint members

**Detailed example**
We usually have to following setup with api clients or database clients:
```swift
// Package APIClient
@DependencyClient
public struct APIClientBookmarks {
  public var fetchBookmarks: @Sendable () async -> [Bookmark] = { [] } 
  // many more endpoints
}
      
@DependencyClient
public struct APIClientVideos {
  public var fetchVideos: @Sendable () async -> [Video] = { [] } 
}
     
@DependencyClient
public struct APIClient {
  public var bookmarks: APIClientBookmarks
  public var videos: APIClientVideos
}
```

Resulting macro expansion from the PR (domain specific dependency client macro expansion is unchanged)
```swift
public struct APIClient {
  public var bookmarks: APIClientBookmarks
  public var videos: APIClientVideos
      
  public init(
    bookmarks: APIClientBookmarks,
    videos: APIClientVideos
  ) {
    self.bookmarks = bookmarks
    self.videos = videos
  }
}
```

Usage in feature code
```swift
class FeatureUsingVideoEndpoint {
  @Dependency(\.apiClient.videos) var videoClient
}
```