### PR TITLE
Support for Swift 6.1 TestScoping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         config: ['debug', 'release']
-        xcode: ['16.0']
+        xcode: ['16.2']
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -119,7 +119,9 @@ import IssueReporting
 public struct DependencyValues: Sendable {
   @TaskLocal public static var _current = Self()
   @TaskLocal static var currentDependency = CurrentDependency()
-  @TaskLocal static var isSetting = false
+  #if DEBUG
+    @TaskLocal static var isSetting = false
+  #endif
   @TaskLocal static var preparationID: UUID?
   static var isPreparing: Bool {
     preparationID != nil

--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -151,7 +151,11 @@ public struct DependencyValues: Sendable {
         }
         let testCaseWillStartImp = imp_implementationWithBlock(testCaseWillStartBlock)
         class_addMethod(
-          TestObserver.self, Selector(("testCaseWillStart:")), testCaseWillStartImp, nil)
+          TestObserver.self,
+          Selector(("testCaseWillStart:")),
+          testCaseWillStartImp,
+          nil
+        )
         class_addProtocol(TestObserver.self, XCTestObservation)
         _ =
           XCTestObservationCenterShared
@@ -394,7 +398,8 @@ public struct DependencyValues: Sendable {
 
   @_spi(Beta)
   @available(
-    *, deprecated,
+    *,
+    deprecated,
     message: "'resetCache' is no longer necessary for most (unparameterized) '@Test' cases"
   )
   public func resetCache() {
@@ -574,21 +579,26 @@ public final class CachedValues: @unchecked Sendable {
             value = Key.previewValue
           }
         case .test:
-          if !CachedValues.isAccessingCachedDependencies,
-            case let .swiftTesting(.some(testing)) = TestContext.current,
-            let testValues = testValuesByTestID.withValue({ $0[testing.test.id.rawValue] })
-          {
-            value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
-              testValues[key]
+          #if compiler(<6.1)
+            if !CachedValues.isAccessingCachedDependencies,
+              case let .swiftTesting(.some(testing)) = TestContext.current,
+              let testValues = testValuesByTestID.withValue({ $0[testing.test.id.rawValue] })
+            {
+              value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
+                testValues[key]
+              }
+            } else {
+              value = Key.testValue
             }
-          } else {
+          #else
             value = Key.testValue
-          }
+          #endif
         }
 
         let cacheableValue = value ?? Key.testValue
         cached[cacheKey] = CachedValue(
-          base: cacheableValue, preparationID: DependencyValues.preparationID
+          base: cacheableValue,
+          preparationID: DependencyValues.preparationID
         )
         return cacheableValue
       }

--- a/Sources/Dependencies/DependencyValues/Date.swift
+++ b/Sources/Dependencies/DependencyValues/Date.swift
@@ -39,10 +39,6 @@ extension DependencyValues {
 
   private enum DateGeneratorKey: DependencyKey {
     static let liveValue = DateGenerator { Date() }
-    static let testValue = DateGenerator {
-      reportIssue(#"Unimplemented: @Dependency(\.date)"#)
-      return Date()
-    }
   }
 }
 

--- a/Sources/Dependencies/DependencyValues/URLSession.swift
+++ b/Sources/Dependencies/DependencyValues/URLSession.swift
@@ -84,11 +84,6 @@
     private enum URLSessionKey: DependencyKey {
       static let liveValue = URLSession.shared
       static var testValue: URLSession {
-        #if DEBUG
-          if !DependencyValues.isSetting {
-            reportIssue(#"Unimplemented: @Dependency(\.urlSession)"#)
-          }
-        #endif
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [UnimplementedURLProtocol.self]
         return URLSession(configuration: configuration)
@@ -98,18 +93,23 @@
 
   private final class UnimplementedURLProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool {
-      true
+      reportIssue(#"Unimplemented: @Dependency(\.urlSession)"#)
+      return true
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-      request
+      reportIssue(#"Unimplemented: @Dependency(\.urlSession)"#)
+      return request
     }
 
     override func startLoading() {
+      reportIssue(#"Unimplemented: @Dependency(\.urlSession)"#)
       struct UnimplementedURLSession: Error {}
       self.client?.urlProtocol(self, didFailWithError: UnimplementedURLSession())
     }
 
-    override func stopLoading() {}
+    override func stopLoading() {
+      reportIssue(#"Unimplemented: @Dependency(\.urlSession)"#)
+    }
   }
 #endif

--- a/Sources/Dependencies/Traits/TestTrait.swift
+++ b/Sources/Dependencies/Traits/TestTrait.swift
@@ -1,1 +1,3 @@
+#if compiler(<6.1)
 package let testValuesByTestID = LockIsolated<[AnyHashable: DependencyValues]>([:])
+#endif

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -133,13 +133,11 @@ public func withDependencies<R>(
   #else
     var dependencies = DependencyValues._current
     try updateValuesForOperation(&dependencies)
-    try DependencyValues.$isSetting.withValue(false) {
-      let result = try operation()
-      if R.self is AnyClass {
-        dependencyObjects.store(result as AnyObject)
-      }
-      return result
+    let result = try operation()
+    if R.self is AnyClass {
+      dependencyObjects.store(result as AnyObject)
     }
+    return result
   #endif
 }
 

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -133,11 +133,13 @@ public func withDependencies<R>(
   #else
     var dependencies = DependencyValues._current
     try updateValuesForOperation(&dependencies)
-    let result = try operation()
-    if R.self is AnyClass {
-      dependencyObjects.store(result as AnyObject)
+    return try DependencyValues.$_current.withValue(dependencies) {
+      let result = try operation()
+      if R.self is AnyClass {
+        dependencyObjects.store(result as AnyObject)
+      }
+      return result
     }
-    return result
   #endif
 }
 

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -597,7 +597,7 @@ private func isSetting<R>(
   #endif
 }
 
-#if compiler(>=6)
+#if compiler(>=6.0.2)
   @_transparent
   private func isSetting<R>(
     _ value: Bool,
@@ -611,15 +611,15 @@ private func isSetting<R>(
     #endif
   }
 #else
-@_transparent
-private func isSetting<R>(
-  _ value: Bool,
-  operation: () async throws -> R
-) async rethrows -> R {
-#if DEBUG
-  try await DependencyValues.$isSetting.withValue(value, operation: operation)
-#else
-  try await operation()
-#endif
-}
+  @_transparent
+  private func isSetting<R>(
+    _ value: Bool,
+    operation: () async throws -> R
+  ) async rethrows -> R {
+    #if DEBUG
+      try await DependencyValues.$isSetting.withValue(value, operation: operation)
+    #else
+      try await operation()
+    #endif
+  }
 #endif

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -597,7 +597,7 @@ private func isSetting<R>(
   #endif
 }
 
-#if swift(>=6)
+#if compiler(>=6)
   @_transparent
   private func isSetting<R>(
     _ value: Bool,

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -602,7 +602,7 @@ private func isSetting<R>(
   private func isSetting<R>(
     _ value: Bool,
     isolation: isolated (any Actor)? = #isolation,
-    operation: () async throws -> R
+    operation: () async throws -> sending R
   ) async rethrows -> R {
     #if DEBUG
       try await DependencyValues.$isSetting.withValue(value, operation: operation)

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -3,111 +3,152 @@
   import Dependencies
   import Testing
 
-  @_documentation(visibility: private)
-  public struct _DependenciesTrait: Sendable {
-    package let updateValues: @Sendable (inout DependencyValues) throws -> Void
+  #if swift(>=6.1)
+    @_documentation(visibility: private)
+    public struct _DependenciesScopeTrait: TestScoping, TestTrait, SuiteTrait {
+      let updateValues: @Sendable (inout DependencyValues) throws -> Void
 
-    package init(_ updateValues: @escaping @Sendable (inout DependencyValues) throws -> Void) {
-      self.updateValues = updateValues
-    }
-  }
-
-  extension Trait where Self == _DependenciesTrait {
-    /// A trait that overrides a test's or suite's dependency.
-    ///
-    /// Useful for overriding a dependency in a test without incurring the nesting and
-    /// indentation of ``withDependencies(_:operation:)-4uz6m``.
-    ///
-    /// ```swift
-    /// @Test(
-    ///   .dependency(\.continuousClock, .immediate)
-    /// )
-    /// func feature() {
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// > Important: Due to [a Swift bug](https://github.com/swiftlang/swift/issues/76409), it is
-    /// > not possible to specify a closure directly inside a `@Suite` or `@Test` macro:
-    /// >
-    /// > ```swift
-    /// > @Suite(
-    /// >   .dependency(\.apiClient.fetchUser, { _ in .mock })  // 🛑
-    /// > )
-    /// > struct FeatureTests { /* ... */ }
-    /// > ```
-    /// >
-    /// > To work around: extract the closure so that it is created outside the macro:
-    /// >
-    /// ```swift
-    /// > private let fetchUser: @Sendable (Int) async throws -> User = { _ in .mock }
-    /// > @Suite(
-    /// >   .dependency(\.apiClient.fetchUser, fetchUser)
-    /// > )
-    /// > struct FeatureTests { /* ... */ }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - keyPath: A key path to a dependency value.
-    ///   - value: A dependency value to override for the test.
-    public static func dependency<Value>(
-      _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
-      _ value: @autoclosure @escaping @Sendable () throws -> Value
-    ) -> Self {
-      Self {
-        $0[keyPath: keyPath] = try value()
+      public var isRecursive: Bool { true }
+      public func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+      ) async throws {
+        try await withDependencies {
+          try updateValues(&$0)
+        } operation: {
+          try await function()
+        }
       }
     }
 
-    /// A trait that overrides a test's or suite's dependency.
-    ///
-    /// Useful for overriding a dependency in a test without incurring the nesting and
-    /// indentation of ``withDependencies(_:operation:)-4uz6m``.
-    ///
-    /// ```swift
-    /// struct Client: DependencyKey { … }
-    /// @Test(
-    ///   .dependency(Client.mock)
-    /// )
-    /// func feature() {
-    ///   // ...
-    /// }
-    /// ```
-    ///
-    /// > Important: Due to [a Swift bug](https://github.com/swiftlang/swift/issues/76409), it is
-    /// > not possible to specify a closure directly inside a `@Suite` or `@Test` macro:
-    /// >
-    /// > ```swift
-    /// > @Suite(
-    /// >   .dependency(Client { _ in .mock })  // 🛑
-    /// > )
-    /// > struct FeatureTests { /* ... */ }
-    /// > ```
-    ///
-    /// - Parameters:
-    ///   - keyPath: A key path to a dependency value.
-    ///   - value: A dependency value to override for the test.
-    public static func dependency<Value: TestDependencyKey>(
-      _ value: @autoclosure @escaping @Sendable () throws -> Value
-    ) -> Self where Value == Value.Value {
-      Self { $0[Value.self] = try value() }
-    }
-
-    /// A trait that overrides a test's or suite's dependencies.
-    public static func dependencies(
-      _ updateValues: @escaping @Sendable (inout DependencyValues) -> Void
-    ) -> Self {
-      Self(updateValues)
-    }
-  }
-
-  extension _DependenciesTrait: SuiteTrait, TestTrait {
-    public var isRecursive: Bool { true }
-
-    public func prepare(for test: Test) async throws {
-      try testValuesByTestID.withValue {
-        try self.updateValues(&$0[test.id, default: DependencyValues(context: .test)])
+    extension Trait where Self == _DependenciesScopeTrait {
+      public static func dependency<Value>(
+        _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
+        _ value: @autoclosure @escaping @Sendable () throws -> Value
+      ) -> Self {
+        Self {
+          $0[keyPath: keyPath] = try value()
+        }
+      }
+      public static func dependency<Value: TestDependencyKey>(
+        _ value: @autoclosure @escaping @Sendable () throws -> Value
+      ) -> Self where Value == Value.Value {
+        Self { $0[Value.self] = try value() }
+      }
+      public static func dependencies(
+        _ updateValues: @escaping @Sendable (inout DependencyValues) -> Void
+      ) -> Self {
+        Self(updateValues: updateValues)
       }
     }
-  }
+  #else
+    @_documentation(visibility: private)
+    public struct _DependenciesTrait: Sendable {
+      package let updateValues: @Sendable (inout DependencyValues) throws -> Void
+
+      package init(_ updateValues: @escaping @Sendable (inout DependencyValues) throws -> Void) {
+        self.updateValues = updateValues
+      }
+    }
+
+    extension Trait where Self == _DependenciesTrait {
+      /// A trait that overrides a test's or suite's dependency.
+      ///
+      /// Useful for overriding a dependency in a test without incurring the nesting and
+      /// indentation of ``withDependencies(_:operation:)-4uz6m``.
+      ///
+      /// ```swift
+      /// @Test(
+      ///   .dependency(\.continuousClock, .immediate)
+      /// )
+      /// func feature() {
+      ///   // ...
+      /// }
+      /// ```
+      ///
+      /// > Important: Due to [a Swift bug](https://github.com/swiftlang/swift/issues/76409), it is
+      /// > not possible to specify a closure directly inside a `@Suite` or `@Test` macro:
+      /// >
+      /// > ```swift
+      /// > @Suite(
+      /// >   .dependency(\.apiClient.fetchUser, { _ in .mock })  // 🛑
+      /// > )
+      /// > struct FeatureTests { /* ... */ }
+      /// > ```
+      /// >
+      /// > To work around: extract the closure so that it is created outside the macro:
+      /// >
+      /// ```swift
+      /// > private let fetchUser: @Sendable (Int) async throws -> User = { _ in .mock }
+      /// > @Suite(
+      /// >   .dependency(\.apiClient.fetchUser, fetchUser)
+      /// > )
+      /// > struct FeatureTests { /* ... */ }
+      /// ```
+      ///
+      /// - Parameters:
+      ///   - keyPath: A key path to a dependency value.
+      ///   - value: A dependency value to override for the test.
+      public static func dependency<Value>(
+        _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
+        _ value: @autoclosure @escaping @Sendable () throws -> Value
+      ) -> Self {
+        Self {
+          $0[keyPath: keyPath] = try value()
+        }
+      }
+
+      /// A trait that overrides a test's or suite's dependency.
+      ///
+      /// Useful for overriding a dependency in a test without incurring the nesting and
+      /// indentation of ``withDependencies(_:operation:)-4uz6m``.
+      ///
+      /// ```swift
+      /// struct Client: DependencyKey { … }
+      /// @Test(
+      ///   .dependency(Client.mock)
+      /// )
+      /// func feature() {
+      ///   // ...
+      /// }
+      /// ```
+      ///
+      /// > Important: Due to [a Swift bug](https://github.com/swiftlang/swift/issues/76409), it is
+      /// > not possible to specify a closure directly inside a `@Suite` or `@Test` macro:
+      /// >
+      /// > ```swift
+      /// > @Suite(
+      /// >   .dependency(Client { _ in .mock })  // 🛑
+      /// > )
+      /// > struct FeatureTests { /* ... */ }
+      /// > ```
+      ///
+      /// - Parameters:
+      ///   - keyPath: A key path to a dependency value.
+      ///   - value: A dependency value to override for the test.
+      public static func dependency<Value: TestDependencyKey>(
+        _ value: @autoclosure @escaping @Sendable () throws -> Value
+      ) -> Self where Value == Value.Value {
+        Self { $0[Value.self] = try value() }
+      }
+
+      /// A trait that overrides a test's or suite's dependencies.
+      public static func dependencies(
+        _ updateValues: @escaping @Sendable (inout DependencyValues) -> Void
+      ) -> Self {
+        Self(updateValues)
+      }
+    }
+
+    extension _DependenciesTrait: SuiteTrait, TestTrait {
+      public var isRecursive: Bool { true }
+
+      public func prepare(for test: Test) async throws {
+        try testValuesByTestID.withValue {
+          try self.updateValues(&$0[test.id, default: DependencyValues(context: .test)])
+        }
+      }
+    }
+  #endif
 #endif

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -23,6 +23,9 @@
     }
 
     extension Trait where Self == _DependenciesScopeTrait {
+      public static var resetDependencies: Self {
+        Self { $0 = DependencyValues() }
+      }
       public static func dependency<Value>(
         _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
         _ value: @autoclosure @escaping @Sendable () throws -> Value

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -30,9 +30,52 @@
     }
 
     extension Trait where Self == _DependenciesScopeTrait {
+      /// A trait that quarantines a test's dependencies from other tests.
+      ///
+      /// When applied to a `@Suite` (or `@Test`), the dependencies used for that suite (or test)
+      /// will be kept separate from any other suites (and tests) running in parallel.
+      ///
+      /// It is recommended to use a base `@Suite` to apply this to all tests. You can do this by
+      /// defining a `@Suite` with the trait:
+      ///
+      /// ```swift
+      /// @Suite(.dependencies) struct BaseSuite {}
+      /// ```
+      ///
+      /// Then any suite or test you write can be nested inside the base suite:
+      ///
+      /// ```swift
+      /// extension BaseSuite {
+      ///   @Suite struct MyTests {
+      ///     @Test func login() {
+      ///       // Dependencies accessed in here are independency from 'logout' tests.
+      ///     }
+      ///
+      ///     @Test func logout() {
+      ///       // Dependencies accessed in here are independency from 'login' tests.
+      ///     }
+      ///   }
+      /// }
+      /// ```
       public static var dependencies: Self {
         Self { _ in }
       }
+      
+      /// A trait that overrides a test's or suite's dependency.
+      ///
+      /// Useful for overriding a dependency in a test without incurring the nesting and
+      /// indentation of ``withDependencies(_:operation:)-4uz6m``.
+      ///
+      /// ```swift
+      /// @Test(.dependency(\.continuousClock, .immediate))
+      /// func feature() {
+      ///   // ...
+      /// }
+      /// ```
+      ///
+      /// - Parameters:
+      ///   - keyPath: A key path to a dependency value.
+      ///   - value: A dependency value to override for the test.
       public static func dependency<Value>(
         _ keyPath: WritableKeyPath<DependencyValues, Value> & Sendable,
         _ value: @autoclosure @escaping @Sendable () throws -> Value
@@ -41,11 +84,44 @@
           $0[keyPath: keyPath] = try value()
         }
       }
+
+      /// A trait that overrides a test's or suite's dependency.
+      ///
+      /// Useful for overriding a dependency in a test without incurring the nesting and
+      /// indentation of ``withDependencies(_:operation:)-4uz6m``.
+      ///
+      /// ```swift
+      /// struct Client: DependencyKey { … }
+      /// @Test(.dependency(Client.mock))
+      /// func feature() {
+      ///   // ...
+      /// }
+      /// ```
+      ///
+      /// - Parameters:
+      ///   - keyPath: A key path to a dependency value.
+      ///   - value: A dependency value to override for the test.
       public static func dependency<Value: TestDependencyKey>(
         _ value: @autoclosure @escaping @Sendable () throws -> Value
       ) -> Self where Value == Value.Value {
         Self { $0[Value.self] = try value() }
       }
+
+      /// A trait that overrides a test's or suite's dependencies.
+      ///
+      /// Useful for overriding a dependency in a test without incurring the nesting and
+      /// indentation of ``withDependencies(_:operation:)-4uz6m``.
+      ///
+      /// ```swift
+      /// @Test(.dependencies {
+      ///   $0.date.now = Date(timeIntervalSince1970: 1234567890)
+      ///   $0.uuid = .incrementing
+      /// })
+      /// func feature() {
+      ///   // ...
+      /// }
+      /// ```
+      ///
       public static func dependencies(
         _ updateValues: @escaping @Sendable (inout DependencyValues) -> Void
       ) -> Self {

--- a/Tests/DependenciesTests/DependencyValuesTests.swift
+++ b/Tests/DependenciesTests/DependencyValuesTests.swift
@@ -716,8 +716,12 @@ final class DependencyValuesTests: XCTestCase {
   @MainActor
   func testDeadlock() async {
     DispatchQueue(label: "queue", qos: .utility).async {
-      @Dependency(\.date) var date
-      _ = date
+      withDependencies {
+        $0.date = $0.date
+      } operation: {
+        @Dependency(\.date) var date
+        _ = date
+      }
     }
 
     // Block main thread for 0.1 seconds.

--- a/Tests/DependenciesTests/PrepareDependenciesTests.swift
+++ b/Tests/DependenciesTests/PrepareDependenciesTests.swift
@@ -4,6 +4,7 @@
   import Testing
 
   @Suite struct PrepareDependenciesTests {
+#if swift(>=6.1)
     @Test(
       .serialized,
       .dependency(\.uuid, .incrementing),
@@ -13,6 +14,23 @@
       @Dependency(\.uuid) var uuid
       #expect(uuid() == UUID(0))
     }
+    #else
+    @Test(
+      .serialized,
+      .dependency(\.uuid, .incrementing),
+      arguments: [1, 2, 3]
+    )
+    func uuid(value: Int) {
+      @Dependency(\.uuid) var uuid
+      if value == 1 {
+        #expect(uuid() == UUID(0))
+      } else {
+        withKnownIssue {
+          #expect(uuid() == UUID(0))
+        }
+      }
+    }
+    #endif
 
     @Test func isolation1() {
       prepareDependencies {

--- a/Tests/DependenciesTests/PrepareDependenciesTests.swift
+++ b/Tests/DependenciesTests/PrepareDependenciesTests.swift
@@ -11,13 +11,7 @@
     )
     func uuid(value: Int) {
       @Dependency(\.uuid) var uuid
-      if value == 1 {
-        #expect(uuid() == UUID(0))
-      } else {
-        withKnownIssue {
-          #expect(uuid() == UUID(0))
-        }
-      }
+      #expect(uuid() == UUID(0))
     }
 
     @Test func isolation1() {

--- a/Tests/DependenciesTests/PreviewTraitsTests.swift
+++ b/Tests/DependenciesTests/PreviewTraitsTests.swift
@@ -8,6 +8,7 @@
   struct PreviewTraitsTests {
     @Test
     @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
+    @available(*, deprecated, message: "")
     func dependency() {
       _ = PreviewTrait.dependency(\.date.now, Date(timeIntervalSince1970: 1_234_567_890))
       withDependencies {

--- a/Tests/DependenciesTests/RootResettingTests.swift
+++ b/Tests/DependenciesTests/RootResettingTests.swift
@@ -1,0 +1,35 @@
+import Dependencies
+import Foundation
+import Testing
+
+@Suite struct RootResettingTests {
+  @Suite
+  struct ResetsAtRootTests {
+    @Test(.dependencies, arguments: [1, 2, 3])
+    func freshDependencies(argument: Int) {
+      @Dependency(Client.self) var client
+      #expect(client.increment() == 1)
+    }
+  }
+  
+  @Suite(.dependency(\.date.now, Date(timeIntervalSince1970: 123)))
+  struct ResetsOnlyAtRootTests {
+    @Test(.dependencies) func date() {
+      @Dependency(\.date.now) var now
+      #expect(now == Date(timeIntervalSince1970: 123))
+    }
+  }
+}
+
+private struct Client: TestDependencyKey {
+  var increment: @Sendable () -> Int
+  static var testValue: Client {
+    let count = LockIsolated(0)
+    return Self {
+      count.withValue {
+        $0 += 1
+        return $0
+      }
+    }
+  }
+}

--- a/Tests/DependenciesTests/RootResettingTests.swift
+++ b/Tests/DependenciesTests/RootResettingTests.swift
@@ -1,35 +1,37 @@
-import Dependencies
-import Foundation
-import Testing
+#if swift(>=6.1) && canImport(Testing)
+  import Dependencies
+  import Foundation
+  import Testing
 
-@Suite struct RootResettingTests {
-  @Suite
-  struct ResetsAtRootTests {
-    @Test(.dependencies, arguments: [1, 2, 3])
-    func freshDependencies(argument: Int) {
-      @Dependency(Client.self) var client
-      #expect(client.increment() == 1)
+  @Suite struct RootResettingTests {
+    @Suite
+    struct ResetsAtRootTests {
+      @Test(.dependencies, arguments: [1, 2, 3])
+      func freshDependencies(argument: Int) {
+        @Dependency(Client.self) var client
+        #expect(client.increment() == 1)
+      }
     }
-  }
-  
-  @Suite(.dependency(\.date.now, Date(timeIntervalSince1970: 123)))
-  struct ResetsOnlyAtRootTests {
-    @Test(.dependencies) func date() {
-      @Dependency(\.date.now) var now
-      #expect(now == Date(timeIntervalSince1970: 123))
-    }
-  }
-}
 
-private struct Client: TestDependencyKey {
-  var increment: @Sendable () -> Int
-  static var testValue: Client {
-    let count = LockIsolated(0)
-    return Self {
-      count.withValue {
-        $0 += 1
-        return $0
+    @Suite(.dependency(\.date.now, Date(timeIntervalSince1970: 123)))
+    struct ResetsOnlyAtRootTests {
+      @Test(.dependencies) func date() {
+        @Dependency(\.date.now) var now
+        #expect(now == Date(timeIntervalSince1970: 123))
       }
     }
   }
-}
+
+  private struct Client: TestDependencyKey {
+    var increment: @Sendable () -> Int
+    static var testValue: Client {
+      let count = LockIsolated(0)
+      return Self {
+        count.withValue {
+          $0 += 1
+          return $0
+        }
+      }
+    }
+  }
+#endif

--- a/Tests/DependenciesTests/SwiftTestingTests.swift
+++ b/Tests/DependenciesTests/SwiftTestingTests.swift
@@ -5,13 +5,6 @@
   import Foundation
   import Testing
 
-@Suite(.dependency(\.self, DependencyValues())) struct BaseSuite {}
-//@Suite(.dependencies) struct BaseSuite {}
-//@Suite(.resetDependencies) struct BaseSuite {}
-//@Suite(.setUpDependencies) struct BaseSuite {}
-//@Suite(.prepareDependencies) struct BaseSuite {}
-
-//extension BaseSuite {
   @Suite struct SwiftTestingTests {
     @Test(.dependencies, .serialized, arguments: 1...5)
     func parameterizedCachePollution(_ argument: Int) {
@@ -49,11 +42,11 @@
       @Dependency(Client.self) var client
       let value = client.increment()
       // NB: Wasm has different behavior here.
-#if os(WASI)
-      #expect(value == 2)
-#else
-      #expect(value == 1)
-#endif
+      #if os(WASI)
+        #expect(value == 2)
+      #else
+        #expect(value == 1)
+      #endif
     }
 
     @Test(.dependency(\.date.now, Date(timeIntervalSinceReferenceDate: 0)))
@@ -128,4 +121,3 @@
     }
   }
 #endif
-//}

--- a/Tests/DependenciesTests/SwiftTestingTests.swift
+++ b/Tests/DependenciesTests/SwiftTestingTests.swift
@@ -5,18 +5,12 @@
   import Foundation
   import Testing
 
-  struct SwiftTestingTests {
+  @Suite(.resetDependencies) struct SwiftTestingTests {
     @Test(.serialized, arguments: 1...5)
     func parameterizedCachePollution(_ argument: Int) {
       @Dependency(Client.self) var client
       let value = client.increment()
-      if argument == 1 {
-        #expect(value == 1)
-      } else {
-        withKnownIssue {
-          #expect(value == 1)
-        }
-      }
+      #expect(value == 1)
     }
 
     @Test(arguments: 1...5)

--- a/Tests/DependenciesTests/SwiftTestingTests.swift
+++ b/Tests/DependenciesTests/SwiftTestingTests.swift
@@ -5,9 +5,22 @@
   import Foundation
   import Testing
 
-  @Suite(.resetDependencies) struct SwiftTestingTests {
-    @Test(.serialized, arguments: 1...5)
+@Suite(.dependency(\.self, DependencyValues())) struct BaseSuite {}
+//@Suite(.dependencies) struct BaseSuite {}
+//@Suite(.resetDependencies) struct BaseSuite {}
+//@Suite(.setUpDependencies) struct BaseSuite {}
+//@Suite(.prepareDependencies) struct BaseSuite {}
+
+//extension BaseSuite {
+  @Suite struct SwiftTestingTests {
+    @Test(.dependencies, .serialized, arguments: 1...5)
     func parameterizedCachePollution(_ argument: Int) {
+      @Dependency(Client.self) var client
+      let value = client.increment()
+      #expect(value == 1)
+    }
+
+    @Test(.dependencies) func repeatedTest() {
       @Dependency(Client.self) var client
       let value = client.increment()
       #expect(value == 1)
@@ -36,11 +49,11 @@
       @Dependency(Client.self) var client
       let value = client.increment()
       // NB: Wasm has different behavior here.
-      #if os(WASI)
-        #expect(value == 2)
-      #else
-        #expect(value == 1)
-      #endif
+#if os(WASI)
+      #expect(value == 2)
+#else
+      #expect(value == 1)
+#endif
     }
 
     @Test(.dependency(\.date.now, Date(timeIntervalSinceReferenceDate: 0)))
@@ -115,3 +128,4 @@
     }
   }
 #endif
+//}

--- a/Tests/DependenciesTests/SwiftTestingTests.swift
+++ b/Tests/DependenciesTests/SwiftTestingTests.swift
@@ -6,18 +6,33 @@
   import Testing
 
   @Suite struct SwiftTestingTests {
-    @Test(.dependencies, .serialized, arguments: 1...5)
-    func parameterizedCachePollution(_ argument: Int) {
-      @Dependency(Client.self) var client
-      let value = client.increment()
-      #expect(value == 1)
-    }
+    #if swift(>=6.1)
+      @Test(.dependencies, .serialized, arguments: 1...5)
+      func parameterizedCachePollution(_ argument: Int) {
+        @Dependency(Client.self) var client
+        let value = client.increment()
+        #expect(value == 1)
+      }
 
-    @Test(.dependencies) func repeatedTest() {
-      @Dependency(Client.self) var client
-      let value = client.increment()
-      #expect(value == 1)
-    }
+      @Test(.dependencies) func repeatedTest() {
+        @Dependency(Client.self) var client
+        let value = client.increment()
+        #expect(value == 1)
+      }
+    #else
+      @Test(.serialized, arguments: 1...5)
+      func parameterizedCachePollution(_ argument: Int) {
+        @Dependency(Client.self) var client
+        let value = client.increment()
+        if argument == 1 {
+          #expect(value == 1)
+        } else {
+          withKnownIssue {
+            #expect(value == 1)
+          }
+        }
+      }
+    #endif
 
     @Test(arguments: 1...5)
     func parameterizedCachePollution_ResetDependencies(_ argument: Int) {

--- a/Tests/DependenciesTests/TestTraitTests.swift
+++ b/Tests/DependenciesTests/TestTraitTests.swift
@@ -4,7 +4,7 @@
   import Foundation
   import Testing
 
-  @Suite(.dependency(\.uuid, .incrementing))
+//  @Suite(.dependency(\.uuid, .incrementing))
   struct TestTraitTests {
     @Dependency(\.uuid) var uuid
 

--- a/Tests/DependenciesTests/TestTraitTests.swift
+++ b/Tests/DependenciesTests/TestTraitTests.swift
@@ -4,7 +4,7 @@
   import Foundation
   import Testing
 
-//  @Suite(.dependency(\.uuid, .incrementing))
+  @Suite(.dependency(\.uuid, .incrementing))
   struct TestTraitTests {
     @Dependency(\.uuid) var uuid
 


### PR DESCRIPTION
Swift 6.1 is now in beta which means we can trade out our hacky support for test traits for the real thing, thanks to `TestScoping`.