### PR TITLE
Add dependencies provider

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "46c7c52f0c1617cc1d5bc47663541c21a6e6734ddf2ad859bf5bf5bc207fa8f4",
+  "originHash" : "9af75795d44ca33d2d2ff1228ae0b2082fad28fb82fe8d750bbc2a258029bc84",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "770f990d3e4eececb57ac04a6076e22f8c97daeb",
-        "version" : "1.4.2"
+        "branch" : "fix-linux-windows",
+        "revision" : "64a5e4f4bf763fa9a9ed7757ae656fa11aadccac"
       }
     }
   ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -29,7 +29,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.4"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", branch: "fix-linux-windows"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
   ],
   targets: [

--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -110,4 +110,21 @@
       }
     }
   }
+
+  extension Trait where Self == _DependenciesTrait {
+    public static func dependencies(
+      _ provider: DependenciesProvider
+    ) -> Self {
+      Self(provider.updateValues)
+    }
+  }
+
+  public struct DependenciesProvider {
+    public init(updateValues: @escaping @Sendable (inout DependencyValues) -> Void) {
+      self.updateValues = updateValues
+    }
+  
+    var updateValues: @Sendable (inout DependencyValues) -> Void
+  }
+
 #endif

--- a/Tests/DependenciesTests/TestTraitTests.swift
+++ b/Tests/DependenciesTests/TestTraitTests.swift
@@ -31,5 +31,20 @@
         try await Task.sleep(for: .milliseconds(1))
       }
     }
+
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+    @Test(.dependencies(.default))
+    func dependenciesProvider() async throws {
+      @Dependency(\.date.now) var now
+      #expect(now.timeIntervalSince1970 == 0)
+    }
+  }
+
+  extension DependenciesProvider {
+    static var `default`: Self {
+      .init {
+        $0.date.now = .init(timeIntervalSince1970: 0)
+      }
+    }
   }
 #endif


### PR DESCRIPTION
When using the existing `@Trait(.dependencies(...))` there is no way to "house" a set of dependencies on a type in order to group them together and make them available via `.` + autocomplete, like for dependency keys.

In order to group them, I'm resorting to a top level private function:

```swift
private let defaultDependencies: @Sendable (inout DependencyValues) -> Void = {
    $0.logger.log = { @Sendable _, _ in }
    $0.shell = .liveValue
}
```

which then at least allows

```swift
    @Test(.dependencies(defaultDependencies))
    func commitCount() async throws {
        try await withGitRepository { path in
            #expect(try await Git.commitCount(at: path) == 57)
        }
    }
```

With the proposed change, I could write this as

```swift
  extension DependenciesProvider {
    static var `default`: Self {
      .init {
         $0.logger.log = { @Sendable _, _ in }
         $0.shell = .liveValue
      }
    }
  }
```

and

```swift
    @Test(.dependencies(.default))
    func commitCount() async throws {
        try await withGitRepository { path in
            #expect(try await Git.commitCount(at: path) == 57)
        }
    }
```

It might not look like a huge difference, but being able to house the dependencies in the `DependenciesProvider` type would allow for succinct use and re-use of them across the test base.

The alternatives all feel a bit clunky:

- top level functions litter the scope and aren't very discoverable
- creating a new type with statics would avoid the top level litter but require referencing of the type each time, i.e. `@Trait(.dependencies(TestDependencies.default))`

Would this be a worthwhile addition? Or is there another way to achieve what I'm trying to do that I'm not seeing?