### PR TITLE
fix: Use proper access control when generating method with `package` ACL

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -143,7 +143,10 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
     if functionType.effectSpecifiers?.asyncSpecifier != nil {
       effectSpecifiers.append("await ")
     }
-    let access = property.modifiers.first { $0.name.tokenKind == .keyword(.public) }
+
+    let access = property.modifiers.first {
+        [.keyword(.public), .keyword(.package)].contains($0.name.tokenKind)
+    }
 
     var decls: [DeclSyntax] = []
 

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -1010,6 +1010,42 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       """#
     }
   }
+  
+  func testAccessPackageWithMethodsEquivalent() {
+    assertMacro {
+      """
+      package struct Client {
+        @DependencyEndpoint
+        package var endpoint: (_ id: Int) -> Void
+      }
+      """
+    } expansion: {
+      #"""
+      package struct Client {
+        package var endpoint: (_ id: Int) -> Void {
+          @storageRestrictions(initializes: _endpoint)
+          init(initialValue) {
+            _endpoint = initialValue
+          }
+          get {
+            _endpoint
+          }
+          set {
+            _endpoint = newValue
+          }
+        }
+
+        package func endpoint(id p0: Int) -> Void {
+          self.endpoint(p0)
+        }
+
+        private var _endpoint: (_ id: Int) -> Void = { _ in
+          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+        }
+      }
+      """#
+    }
+  }
 
   func testComments() {
     assertMacro {


### PR DESCRIPTION
Context -> #349 
