### PR TITLE
Prevent potential simultaneous access to cached values during cache reset

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -291,55 +291,23 @@ public struct DependencyValues: Sendable {
         let cacheKey = CachedValues.CacheKey(id: TypeIdentifier(key), context: context)
         guard !cachedValues.cached.keys.contains(cacheKey) else {
           if cachedValues.cached[cacheKey]?.preparationID != DependencyValues.preparationID {
-            reportIssue(
-              {
-                var dependencyDescription = ""
-                if let fileID = DependencyValues.currentDependency.fileID,
-                  let line = DependencyValues.currentDependency.line
-                {
-                  dependencyDescription.append(
-                    """
-                      Location:
-                        \(fileID):\(line)
+            reportDependencyIssue(
+              message: { argument, dependencyDescription in
+                """
+                @Dependency(\(argument)) has already been accessed or prepared.
 
-                    """
-                  )
-                }
-                dependencyDescription.append(
-                  Key.self == Key.Value.self
-                    ? """
-                      Dependency:
-                        \(typeName(Key.Value.self))
-                    """
-                    : """
-                      Key:
-                        \(typeName(Key.self))
-                      Value:
-                        \(typeName(Key.Value.self))
-                    """
-                )
-                var argument: String {
-                  "\(function)" == "subscript(key:)"
-                    ? "\(typeName(Key.self)).self"
-                    : "\\.\(function)"
-                }
-                return """
-                  @Dependency(\(argument)) has already been accessed or prepared.
+                \(dependencyDescription)
 
-                  \(dependencyDescription)
+                A global dependency can only be prepared a single time and cannot be accessed \
+                beforehand. Prepare dependencies as early as possible in the lifecycle of your \
+                application.
 
-                  A global dependency can only be prepared a single time and cannot be accessed \
-                  beforehand. Prepare dependencies as early as possible in the lifecycle of your \
-                  application.
-
-                  To temporarily override a dependency in your application, use 'withDependencies' \
-                  to do so in a well-defined scope.
-                  """
-              }(),
-              fileID: DependencyValues.currentDependency.fileID ?? fileID,
-              filePath: DependencyValues.currentDependency.filePath ?? filePath,
-              line: DependencyValues.currentDependency.line ?? line,
-              column: DependencyValues.currentDependency.column ?? column
+                To temporarily override a dependency in your application, use 'withDependencies' \
+                to do so in a well-defined scope.
+                """
+              },
+              for: Key.self,
+              fileID: fileID, filePath: filePath, function: function, line: line, column: column
             )
           } else {
             cachedValues.cached[cacheKey] = CachedValues.CachedValue(
@@ -457,6 +425,7 @@ private let defaultContext: DependencyContext = {
 @_spi(Internals)
 public final class CachedValues: @unchecked Sendable {
   @TaskLocal static var isAccessingCachedDependencies = false
+  @TaskLocal static var isResetting = false
 
   public struct CacheKey: Hashable, Sendable {
     let id: TypeIdentifier
@@ -486,7 +455,9 @@ public final class CachedValues: @unchecked Sendable {
   public func resetCache() {
     lock.lock()
     defer { lock.unlock() }
-    cached = [:]
+    Self.$isResetting.withValue(true) {
+        cached = [:]
+    }
   }
 
   func value<Key: TestDependencyKey>(
@@ -509,65 +480,54 @@ public final class CachedValues: @unchecked Sendable {
           !(cached[cacheKey] != nil && cached[cacheKey]?.preparationID != nil),
           !(key is any DependencyKey.Type)
         {
-          reportIssue(
-            {
-              var dependencyDescription = ""
-              if let fileID = DependencyValues.currentDependency.fileID,
-                let line = DependencyValues.currentDependency.line
-              {
-                dependencyDescription.append(
-                  """
-                    Location:
-                      \(fileID):\(line)
+          reportDependencyIssue(
+            message: { argument, dependencyDescription in
+              """
+              @Dependency(\(argument)) has no live implementation, but was accessed from a live \
+              context.
 
-                  """
-                )
-              }
-              dependencyDescription.append(
-                Key.self == Key.Value.self
-                  ? """
-                    Dependency:
-                      \(typeName(Key.Value.self))
-                  """
-                  : """
-                    Key:
-                      \(typeName(Key.self))
-                    Value:
-                      \(typeName(Key.Value.self))
-                  """
-              )
+              \(dependencyDescription)
 
-              var argument: String {
-                "\(function)" == "subscript(key:)"
-                  ? "\(typeName(Key.self)).self"
-                  : "\\.\(function)"
-              }
-              return """
-                @Dependency(\(argument)) has no live implementation, but was accessed from a live \
-                context.
+              To fix you can do one of two things:
 
-                \(dependencyDescription)
+              • Conform '\(typeName(Key.self))' to the 'DependencyKey' protocol by providing \
+              a live implementation of your dependency, and make sure that the conformance is \
+              linked with this current application.
 
-                To fix you can do one of two things:
-
-                • Conform '\(typeName(Key.self))' to the 'DependencyKey' protocol by providing \
-                a live implementation of your dependency, and make sure that the conformance is \
-                linked with this current application.
-
-                • Override the implementation of '\(typeName(Key.self))' using \
-                'withDependencies'. This is typically done at the entry point of your \
-                application, but can be done later too.
-                """
-            }(),
-            fileID: DependencyValues.currentDependency.fileID ?? fileID,
-            filePath: DependencyValues.currentDependency.filePath ?? filePath,
-            line: DependencyValues.currentDependency.line ?? line,
-            column: DependencyValues.currentDependency.column ?? column
+              • Override the implementation of '\(typeName(Key.self))' using \
+              'withDependencies'. This is typically done at the entry point of your \
+              application, but can be done later too.
+              """
+            },
+            for: Key.self,
+            fileID: fileID, filePath: filePath, function: function, line: line, column: column
           )
         }
       #endif
 
-      guard let base = cached[cacheKey]?.base, let value = base as? Key.Value
+      #if DEBUG
+      let isResetting = Self.isResetting
+      if isResetting {
+        reportDependencyIssue(
+          message: { argument, dependencyDescription in
+            """
+            @Dependency(\(argument)) was access during a cache reset.
+
+            \(dependencyDescription)
+
+            Accessing a dependency during a cache reset will always return a new and uncached \
+            instance of the dependency.
+            """
+          },
+          for: Key.self,
+          fileID: fileID, filePath: filePath, function: function, line: line, column: column
+        )
+      }
+      #else
+      let isResetting = false
+      #endif
+      
+      guard !isResetting, let base = cached[cacheKey]?.base, let value = base as? Key.Value
       else {
         let value: Key.Value?
         switch context {
@@ -606,16 +566,68 @@ public final class CachedValues: @unchecked Sendable {
         }
 
         let cacheableValue = value ?? Key.testValue
-        cached[cacheKey] = CachedValue(
-          base: cacheableValue,
-          preparationID: DependencyValues.preparationID
-        )
+        if !isResetting {
+          cached[cacheKey] = CachedValue(
+            base: cacheableValue,
+            preparationID: DependencyValues.preparationID
+          )
+        }
         return cacheableValue
       }
 
       return value
     }
   }
+}
+
+public func reportDependencyIssue<Key: TestDependencyKey>(
+  message: (_ argument: String, _ dependencyDescription: String) -> String,
+  for key: Key.Type,
+  fileID: StaticString,
+  filePath: StaticString,
+  function: StaticString,
+  line: UInt,
+  column: UInt
+) {
+  var dependencyDescription = ""
+  if let fileID = DependencyValues.currentDependency.fileID,
+    let line = DependencyValues.currentDependency.line
+  {
+    dependencyDescription.append(
+      """
+        Location:
+          \(fileID):\(line)
+
+      """
+    )
+  }
+  dependencyDescription.append(
+    Key.self == Key.Value.self
+      ? """
+        Dependency:
+          \(typeName(Key.Value.self))
+      """
+      : """
+        Key:
+          \(typeName(Key.self))
+        Value:
+          \(typeName(Key.Value.self))
+      """
+  )
+  
+  var argument: String {
+    "\(function)" == "subscript(key:)"
+      ? "\(typeName(Key.self)).self"
+      : "\\.\(function)"
+  }
+  
+  reportIssue(
+    message(argument, dependencyDescription),
+    fileID: DependencyValues.currentDependency.fileID ?? fileID,
+    filePath: DependencyValues.currentDependency.filePath ?? filePath,
+    line: DependencyValues.currentDependency.line ?? line,
+    column: DependencyValues.currentDependency.column ?? column
+  )
 }
 
 struct TypeIdentifier: Hashable {

--- a/Tests/DependenciesTests/CacheTests.swift
+++ b/Tests/DependenciesTests/CacheTests.swift
@@ -13,6 +13,35 @@ final class CachedValueTests: XCTestCase {
     @Dependency(OuterDependencyTests.self) var outerDependency
     _ = outerDependency
   }
+  
+  func testDeinitCacheAccess() {
+    struct NestedDependency: TestDependencyKey {
+      static let testValue = NestedDependency()
+    }
+    
+    final class RefDependency: TestDependencyKey, Sendable {
+      deinit {
+        @Dependency(NestedDependency.self) var nested
+        _ = nested
+      }
+      
+      static var testValue: RefDependency { RefDependency() }
+    }
+
+    XCTExpectFailure {
+      @Dependency(RefDependency.self) var refDependency
+      _ = refDependency
+      
+      // Reset the cache to trigger RefDependency deinit
+      DependencyValues._current.cachedValues.resetCache()
+    } issueMatcher: { issue in
+      // Accessing a value during cache reset accesses both DependencyContextKey and the accessed
+      // dependency. Just match on the end of the error message to cover both keys.
+      issue.compactDescription.hasSuffix(
+        "Accessing a dependency during a cache reset will always return a new and uncached instance of the dependency."
+      )
+    }
+  }
 }
 
 private struct OuterDependencyTests: TestDependencyKey {


### PR DESCRIPTION
I ran into an issue where one our mock dependencies is holding onto a type which accesses a different dependency during deinit.

When the cache is reset the mock dependency is released and the instance it's holding calls its deinit method, which causes it to attempt to access the dependency cache while the cache is still being written to, resulting in a simultaneous access exception. 

<img width="860" alt="Screenshot 2025-03-12 at 8 47 13 AM" src="https://github.com/user-attachments/assets/b1e3075d-7129-4d07-914c-3eeab374fe31" />

In our instance this wouldn't come up in production both because we never reset the cache in production, but also because the live implementation of the dependency vends new instances of the reference type for every call rather than holding onto a shared instance internally.

The `reportDependencyIssue` change isn't required, but I didn't feel like adding a third instance of the complicated `argument` and `dependencyDescription` logic.