### PR TITLE
Resolves issue with endpoints not reporting errors when there's a custom closure

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -32,12 +32,6 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
 
     return [
       """
-      @storageRestrictions(initializes: _\(raw: identifier))
-      init(initialValue) {
-      _\(raw: identifier) = initialValue
-      }
-      """,
-      """
       get {
       _\(raw: identifier)
       }

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -816,10 +816,6 @@ final class DependencyClientMacroTests: BaseTestCase {
       struct Client {
         @available(iOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(macOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(tvOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(watchOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.")
         var fetch: (_ id: Int) throws -> String {
-          @storageRestrictions(initializes: _fetch)
-          init(initialValue) {
-            _fetch = initialValue
-          }
           get {
             _fetch
           }
@@ -864,10 +860,6 @@ final class DependencyClientMacroTests: BaseTestCase {
       struct Client {
         @available(iOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(macOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(tvOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(watchOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.")
         var fetch: (_ id: Int) throws -> String {
-          @storageRestrictions(initializes: _fetch)
-          init(initialValue) {
-            _fetch = initialValue
-          }
           get {
             _fetch
           }
@@ -910,10 +902,6 @@ final class DependencyClientMacroTests: BaseTestCase {
       #"""
       struct Client {
         var fetch: (Int) throws -> String {
-          @storageRestrictions(initializes: _fetch)
-          init(initialValue) {
-            _fetch = initialValue
-          }
           get {
             _fetch
           }

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientTests.swift
@@ -19,16 +19,23 @@ final class DependencyClientTests: BaseTestCase {
     }
   }
 
-  func testSwiftBug() {
+  func testUnimplementedWithNonThrowingEndpoint() {
     let client = ClientWithNonThrowingEndpoint()
 
-    // NB: This should cause a test failure but currently does not due to a Swift compiler bug:
-    //     https://github.com/apple/swift/issues/71070
-    XCTAssertEqual(client.fetch(), 42)
+    XCTExpectFailure {
+      XCTAssertEqual(client.fetch(), 42)
+    } issueMatcher: {
+      $0.compactDescription == """
+        failed - Unimplemented: \'ClientWithNonThrowingEndpoint.fetch\'
+        """
+    }
 
     XCTExpectFailure {
       XCTAssertEqual(client.fetchWithUnimplemented(), 42)
     } issueMatcher: {
+      $0.compactDescription == """
+        failed - Unimplemented: \'ClientWithNonThrowingEndpoint.fetchWithUnimplemented\'
+        """ ||
       $0.compactDescription == """
         failed - Unimplemented …
 

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -24,10 +24,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -56,10 +52,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Bool {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -110,10 +102,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Bool {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -164,10 +152,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: (Int, Bool, String) -> Bool {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -197,10 +181,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () throws -> Bool {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -230,10 +210,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       public struct ApiClient {
         public var apiRequest: @Sendable (ServerRoute.Api.Route) async throws -> (Data, URLResponse) {
-          @storageRestrictions(initializes: _apiRequest)
-          init(initialValue) {
-            _apiRequest = initialValue
-          }
           get {
             _apiRequest
           }
@@ -263,10 +239,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> () {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -295,10 +267,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Int? {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -328,10 +296,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Optional<Int> {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -361,10 +325,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: @Sendable (Int) -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -393,10 +353,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       public struct Client {
         public var endpoint: @Sendable (String, _ id: Int, _ progress: Float) async -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -430,10 +386,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       public struct Client {
         public var endpoint: @MainActor @Sendable (_ id: Int) async -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -467,10 +419,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       public struct Client {
         public var endpoint: @Sendable (_ id: Int) async -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -504,10 +452,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: (_ id: Int) -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -540,10 +484,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -596,10 +536,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: (_ id: Int) -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -649,10 +585,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       #"""
       var `return`: () throws -> Int {
-          @storageRestrictions(initializes: _return)
-          init(initialValue) {
-              _return = initialValue
-          }
           get {
               _return
           }
@@ -678,10 +610,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
     } expansion: {
       #"""
       var `return`: (_ id: Int) throws -> Int {
-          @storageRestrictions(initializes: _return)
-          init(initialValue) {
-              _return = initialValue
-          }
           get {
               _return
           }
@@ -737,10 +665,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Blah {
         public var doAThing: (_ value: Int) -> String {
-          @storageRestrictions(initializes: _doAThing)
-          init(initialValue) {
-            _doAThing = initialValue
-          }
           get {
             _doAThing
           }
@@ -776,10 +700,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Blah {
         public var doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String {
-          @storageRestrictions(initializes: _doAThing)
-          init(initialValue) {
-            _doAThing = initialValue
-          }
           get {
             _doAThing
           }
@@ -813,10 +733,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Foo {
         var bar: (_ a: @autoclosure () -> Int, _ b: () -> Int, _ c: @autoclosure () -> Int) -> Void {
-          @storageRestrictions(initializes: _bar)
-          init(initialValue) {
-            _bar = initialValue
-          }
           get {
             _bar
           }
@@ -891,10 +807,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Blah {
         public var foo: () -> Void {
-          @storageRestrictions(initializes: _foo)
-          init(initialValue) {
-            _foo = initialValue
-          }
           get {
             _foo
           }
@@ -910,10 +822,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
           }()
         }
         public var bar: () -> String {
-          @storageRestrictions(initializes: _bar)
-          init(initialValue) {
-            _bar = initialValue
-          }
           get {
             _bar
           }
@@ -952,11 +860,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
           willSet {
             print("!")
           }
-          @storageRestrictions(initializes: _foo)
-          init(initialValue) {
-            _foo = initialValue
-          }
-
           get {
             _foo
           }
@@ -991,10 +894,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       package struct Client {
         package var endpoint: () -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -1023,10 +922,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       package struct Client {
         package var endpoint: (_ id: Int) -> Void {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }
@@ -1059,10 +954,6 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       #"""
       struct Client {
         var endpoint: () -> Void // This is a comment {
-          @storageRestrictions(initializes: _endpoint)
-          init(initialValue) {
-            _endpoint = initialValue
-          }
           get {
             _endpoint
           }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointTests.swift
@@ -26,10 +26,13 @@
           var endpoint: () -> Int = { 42 }
         }
         let client = Client()
-        // NB: This invocation of 'endpoint' *should* fail, but it does not due to a bug in the
-        //     Swift compiler: https://github.com/apple/swift/issues/71070
-        let output = client.endpoint()
-        XCTAssert(output == 42)
+        XCTExpectFailure {
+          _ = client.endpoint()
+        } issueMatcher: {
+          $0.compactDescription == """
+            failed - Unimplemented: 'Client.endpoint'
+            """
+        }
       }
     #endif
   }


### PR DESCRIPTION
Resolves issue #183

After [getting feedback from the swift team](https://github.com/swiftlang/swift/issues/71070#issuecomment-2780647105) on an issue that seems to be on the swift side I modified the endpoint macro to follow their advice. Simply removing the member initializer accessor.

I also modified all tests so they pass. 

I tested on a project that uses dependencies a lot and it all still works. I also tested removing some `unimplemented` from my closures and checking if tests fail and they do.