### PR TITLE
chore: Remove no longer relevant warning in Designing dependencies documentation page

### DIFF
--- a/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/DesigningDependencies.md
@@ -232,25 +232,5 @@ dependency from the implementation (see
 <doc:LivePreviewTest#Separating-interface-and-implementation> for more information). But now there
 is no need to maintain that code as it is automatically provided for you by the macro.
 
-> Warning: Due to a [bug in the Swift compiler](https://github.com/apple/swift/issues/71070), 
-> endpoints that are not throwing will not emit a test failure when invoked. This applies to 
-> dependencies with endpoints like this:
->
-> ```swift
-> @DependencyClient
-> struct NumberFetcher {
->   var get: () async -> Int = { 42 }
-> }
-> ```
->
-> The workaround is to invoke `reportIssue` directly in the closure:
->
-> ```swift
-> @DependencyClient
-> struct NumberFetcher {
->   var get: () async -> Int = { reportIssue("\(Self.self).get"); return 42 }
-> }
-> ```
-
 [designing-deps]: https://www.pointfree.co/collections/dependencies
 [issue-reporting-gh]: http://github.com/pointfreeco/swift-issue-reporting


### PR DESCRIPTION
Hi!
I saw that in the 1.9.1 a fix was done in #355 to don't have to specify `reportIssue` anymore in non throwing closures.
This case was mentioned in the documentation [here](https://swiftpackageindex.com/pointfreeco/swift-dependencies/1.9.1/documentation/dependencies/designingdependencies#DependencyClient-macro) 

![CleanShot 2025-04-09 at 16 06 33](https://github.com/user-attachments/assets/21168006-de9b-4ed6-a745-024b4be83e8f)

Since it's was fixed I think we can now remove this part from the documentation.
