### PR TITLE
Allow dependencies test trait to throw.

### DIFF
--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -123,7 +123,7 @@
       /// ```
       ///
       public static func dependencies(
-        _ updateValues: @escaping @Sendable (inout DependencyValues) -> Void
+        _ updateValues: @escaping @Sendable (inout DependencyValues) throws -> Void
       ) -> Self {
         Self(updateValues: updateValues)
       }


### PR DESCRIPTION
I think it was an oversight that we did not allow the trailing closure of `.dependencies` to throw.