### PR TITLE
Add init accessor to DependencyEndpoint macro

### DIFF
--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -204,7 +204,7 @@ public macro DependencyClient() =
 /// ```
 @attached(accessor, names: named(init), named(get), named(set))
 @attached(peer, names: arbitrary)
-public macro DependencyEndpoint(method: String = "") =
+public macro DependencyEndpoint(method: String = "", initAccessor: Bool = false) =
   #externalMacro(
     module: "DependenciesMacrosPlugin", type: "DependencyEndpointMacro"
   )


### PR DESCRIPTION
I'm attempting to fix behavior that broke after #355.

cc @mbrandonw

---

Still in draft because it would have a possible bug that were removed from documentation in release 1.9.2:

<details>
<summary>Old bug</summary>

<img width="1133" alt="Screenshot 2025-04-23 at 11 28 40" src="https://github.com/user-attachments/assets/c4688bbb-977d-46f0-908b-f2de817fc0b4" />

</details>

I'm open to ideas on how we can fix this. 

If we can't, probably asking everyone to provide own init is better than have this bug still here.

The library works fine with all old cases, and I just found one specific case that would break it, but it can be avoided with custom init.