### PR TITLE
TestTrait throwing fix for pre-6.1

### DIFF
--- a/Sources/DependenciesTestSupport/TestTrait.swift
+++ b/Sources/DependenciesTestSupport/TestTrait.swift
@@ -221,7 +221,7 @@
 
       /// A trait that overrides a test's or suite's dependencies.
       public static func dependencies(
-        _ updateValues: @escaping @Sendable (inout DependencyValues) -> Void
+        _ updateValues: @escaping @Sendable (inout DependencyValues) throws -> Void
       ) -> Self {
         Self(updateValues)
       }


### PR DESCRIPTION
We only fixed the `throws` availability on 6.1+.