### PR TITLE
Fix for building Dependencies for WASM targets.

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -282,10 +282,12 @@ public struct DependencyValues: Sendable {
     }
     set {
       if DependencyValues.isPreparing {
+        #if canImport(SwiftUI)
         if context == .preview, Thread.isPreviewAppEntryPoint {
           reportIssue("Ignoring dependencies prepared in preview app entry point")
           return
         }
+        #endif
         cachedValues.lock.lock()
         defer { cachedValues.lock.unlock() }
         let cacheKey = CachedValues.CacheKey(id: TypeIdentifier(key), context: context)
@@ -574,9 +576,11 @@ public final class CachedValues: @unchecked Sendable {
         case .live:
           value = (key as? any DependencyKey.Type)?.liveValue as? Key.Value
         case .preview:
+          #if canImport(SwiftUI)
           if Thread.isPreviewAppEntryPoint {
             return Key.previewValue
           }
+          #endif
           if !CachedValues.isAccessingCachedDependencies {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
               return Key.previewValue

--- a/Sources/Dependencies/Internal/AppEntryPoint.swift
+++ b/Sources/Dependencies/Internal/AppEntryPoint.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if canImport(SwiftUI)
 extension Thread {
   static var isPreviewAppEntryPoint: Bool {
     guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
@@ -18,6 +19,7 @@ extension Thread {
     return isPreviewAppEntryPoint
   }
 }
+#endif
 
 extension String {
   fileprivate func containsSymbol(_ symbol: String) -> Bool {


### PR DESCRIPTION
Hi,
Thread type is not yet available in SwiftWasm Foundation, causing compilation errors for WASM targets. This PR is attempting to fix those errors.
