### PR TITLE
Try importing `Musl` if `Glibc` isn't available

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -5,8 +5,10 @@ import IssueReporting
   import WinSDK
 #elseif canImport(Android)
   import Android
-#elseif os(Linux)
+#elseif canImport(Glibc)
   import Glibc
+#elseif canImport(Musl)
+  import Musl
 #endif
 // WASI does not support dynamic linking
 #if os(WASI)


### PR DESCRIPTION
This improves platform support by letting the library be compiled by e.g. the Swift Static Linux SDK. The import pattern follows [an example][example] presented in the Swift docs.

[example]: https://www.swift.org/documentation/articles/static-linux-getting-started.html#:~:text=If%20you%20are%20using%20such