### PR TITLE
Address potential preview warnings

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -286,38 +286,6 @@ public struct DependencyValues: Sendable {
       if DependencyValues.isPreparing {
         #if canImport(SwiftUI)
           if context == .preview, Thread.isPreviewAppEntryPoint {
-            reportIssue(
-              """
-              Xcode Previews: Ignoring dependencies prepared in app entry point.
-
-              To silence this warning, use the dependency context to conditionally prepare them:
-
-                  import Dependencies
-                  import SwiftUI
-
-                  @main
-                  struct MyApp: App {
-                +   @Dependency(\\.context) var context
-                    init() {
-                +     // Don't prepare app dependencies in previews/tests.
-                +     guard context == .live else { return }
-                      prepareDependencies {
-                        // ...
-                      }
-                      // ...
-                    }
-
-                    var body: some Scene {
-                      WindowGroup {
-                +       // Don't load root view in previews/tests.
-                +       if context == .live {
-                          // ...
-                +       }
-                      }
-                    }
-                  }
-              """
-            )
             return
           }
         #endif


### PR DESCRIPTION
We currently allow folks to use `prepareDependencies` in the body of a preview, which works great. It does appear that previews have gotten fancier, especially in Xcode 26, where a preview session stays live even during changes to view code. These changes cause the preview body to re-evaluate, triggering `prepareDependencies` all over again, and spitting out a large purple warning into the preview console.

The behavior of `prepareDependencies` is to ignore future calls and surface warnings in to catch misuse, but maybe we should only emit these warnings in the application. Preview environments are a bit treacherous as is, with app entry point code leaking into them, and preview trait code executing across multiple previews in a file. And so this branch proposes silencing this warning in previews entirely.

This PR also removes the warning about ignoring app entry point dependencies in previews, as the warning was not super useful in practice.