### PR TITLE
Fix UUID ambiguity on Windows

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -124,7 +124,7 @@ public struct DependencyValues: Sendable {
   #if DEBUG
     @TaskLocal static var isSetting = false
   #endif
-  @TaskLocal static var preparationID: UUID?
+  @TaskLocal static var preparationID: Foundation.UUID?
   static var isPreparing: Bool {
     preparationID != nil
   }
@@ -482,7 +482,7 @@ public final class CachedValues: @unchecked Sendable {
 
   public struct CachedValue {
     let base: any Sendable
-    let preparationID: UUID?
+    let preparationID: Foundation.UUID?
   }
 
   public let lock = NSRecursiveLock()


### PR DESCRIPTION
WinSDK has this typedef `typedef GUID UUID` in one of its included headers (rpcdce.h). This causes ambiguity as the compiler does not know which UUID to pick.

I guess there are other ways to solve it (such as defining a `UUID` `typealias` for Windows platform to make it point to `Foundation`. But I'm not sure if that could cause other issues to consumers.


Details of the error:
```
\Sources\Dependencies\DependencyValues.swift:485:24: error: 'UUID' is ambiguous for type lookup in this context
483 |   public struct CachedValue {
484 |     let base: any Sendable
485 |     let preparationID: UUID?
    |                        `- error: 'UUID' is ambiguous for type lookup in this context
486 |   }
487 |

C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\shared\rpcdce.h:83:14: note: found this candidate
  81 | #ifndef UUID_DEFINED
  82 | #define UUID_DEFINED
  83 | typedef GUID UUID;
     |              `- note: found this candidate
  84 | #ifndef uuid_t
  85 | #define uuid_t UUID

FoundationEssentials.UUID:2:15: note: found this candidate
 1 | @available(macOS 10.8, iOS 6.0, tvOS 9.0, watchOS 2.0, *)
 2 | public struct UUID : Hashable, Equatable, CustomStringConvertible, Sendable {
   |               `- note: found this candidate
 3 |     public private(set) var uuid: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) { get }
 4 |     public init()
```