### PR TITLE
Fix '\.assert' dependency for Swift Testing.

### DIFF
--- a/Sources/Dependencies/DependencyValues/Assert.swift
+++ b/Sources/Dependencies/DependencyValues/Assert.swift
@@ -117,7 +117,7 @@ private struct TestAssertionEffect: AssertionEffect {
     line: UInt
   ) {
     guard condition() else {
-      reportIssue(message(), fileID: file, filePath: file, line: line, column: 0)
+      reportIssue(message(), fileID: file, filePath: file, line: line, column: 1)
       return
     }
   }

--- a/Tests/DependenciesTests/AssertTests.swift
+++ b/Tests/DependenciesTests/AssertTests.swift
@@ -1,4 +1,5 @@
 import Dependencies
+import Testing
 import XCTest
 
 final class AssertTests: XCTestCase {
@@ -38,4 +39,17 @@ final class AssertTests: XCTestCase {
       }
     }
   #endif
+}
+
+struct AssertTests_SwiftTesting {
+  @Dependency(\.assert) var assert
+
+  @Test func assertDependency() {
+    withKnownIssue {
+      assert(false)
+    }
+    withKnownIssue {
+      assert(false, "This shouldn't happen.")
+    }
+  }
 }


### PR DESCRIPTION
@JonDuenas Found that when `\.assert` is used in Swift Testing it crashes. Turns out it's just our hard coding of `column: 0`. 