### PR TITLE
Improve `#Preview` app entry point detection

### DIFF
--- a/Sources/Dependencies/DependencyValues.swift
+++ b/Sources/Dependencies/DependencyValues.swift
@@ -284,11 +284,6 @@ public struct DependencyValues: Sendable {
     }
     set {
       if DependencyValues.isPreparing {
-        #if canImport(SwiftUI)
-          if context == .preview, Thread.isPreviewAppEntryPoint {
-            return
-          }
-        #endif
         cachedValues.lock.lock()
         defer { cachedValues.lock.unlock() }
         let cacheKey = CachedValues.CacheKey(id: TypeIdentifier(key), context: context)
@@ -579,11 +574,6 @@ public final class CachedValues: @unchecked Sendable {
         case .live:
           value = (key as? any DependencyKey.Type)?.liveValue as? Key.Value
         case .preview:
-          #if canImport(SwiftUI)
-            if Thread.isPreviewAppEntryPoint {
-              return Key.previewValue
-            }
-          #endif
           if !CachedValues.isAccessingCachedDependencies {
             value = CachedValues.$isAccessingCachedDependencies.withValue(true) {
               return Key.previewValue

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -81,6 +81,11 @@ public func prepareDependencies<R>(
   _ updateValues: (inout DependencyValues) throws -> R
 ) rethrows -> R {
   var dependencies = DependencyValues._current
+  #if canImport(SwiftUI)
+    if Thread.isPreviewAppEntryPoint {
+      dependencies = DependencyValues()
+    }
+  #endif
   return try DependencyValues.$preparationID.withValue(UUID()) {
     #if DEBUG
       try DependencyValues.$isSetting.withValue(true) {


### PR DESCRIPTION
Currently we detect this deep in `DependencyValues`, but we can localize it in `prepareDependencies` instead and avoid potential preview crashes.