### PR TITLE
Fix import ConcurrencyExtras.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,11 +60,7 @@ let package = Package(
           package: "combine-schedulers",
           condition: .when(traits: ["CombineSchedulers"])
         ),
-        .product(
-          name: "ConcurrencyExtras",
-          package: "swift-concurrency-extras",
-          condition: .when(traits: ["Foundation"])
-        ),
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]

--- a/Sources/Dependencies/Internal/Exports.swift
+++ b/Sources/Dependencies/Internal/Exports.swift
@@ -4,8 +4,6 @@
 #if CombineSchedulers
 @_exported import CombineSchedulers
 #endif
-#if Foundation
 @_exported import ConcurrencyExtras
-#endif
 @_exported import IssueReporting
 @_exported import XCTestDynamicOverlay


### PR DESCRIPTION
ConcurrencyExtras is used more broadly than just when the Foundation trait is on.