### PR TITLE
Fix stale documentation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/pointfreeco/swift-dependencies/discussions
     about: Dependencies Q&A, ideas, and more
   - name: Documentation
-    url: https://pointfreeco.github.io/swift-dependencies/main/documentation/dependencies/
+    url: https://swiftpackageindex.com/pointfreeco/swift-dependencies/main/documentation/dependencies
     about: Read documentation for Dependencies
   - name: Videos
     url: https://www.pointfree.co/collections/composable-architecture/reducer-protocol/ep205-reducer-protocol-dependencies-part-1

--- a/README.md
+++ b/README.md
@@ -312,4 +312,4 @@ This library is released under the MIT license. See [LICENSE](LICENSE) for detai
 [swiftui-nav-gh]: http://github.com/pointfreeco/swiftui-navigation
 [dep-values-docs]: https://swiftpackageindex.com/pointfreeco/swift-dependencies/main/documentation/dependencies/dependencyvalues#dependency-values
 [withdependencies-docs]: https://swiftpackageindex.com/pointfreeco/swift-dependencies/main/documentation/dependencies/withdependencies(isolation:_:operation:)
-[immediate-clock-docs]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/immediateclock
+[immediate-clock-docs]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/immediateclock

--- a/Sources/Dependencies/DependencyValues/Clocks.swift
+++ b/Sources/Dependencies/DependencyValues/Clocks.swift
@@ -28,10 +28,10 @@
       ///
       /// See ``suspendingClock`` to override a feature's `SuspendingClock`, instead.
       ///
-      /// [immediate-clock]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/immediateclock/
-      /// [test-clock]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/testclock/
+      /// [immediate-clock]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/immediateclock
+      /// [test-clock]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/testclock
       /// [swift-clocks]: https://github.com/pointfreeco/swift-clocks
-      /// [unimplemented-clock]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/unimplementedclock/
+      /// [unimplemented-clock]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/unimplementedclock
       public var continuousClock: any Clock<Duration> {
         get { self[ContinuousClockKey.self] }
         set { self[ContinuousClockKey.self] = newValue }
@@ -61,10 +61,10 @@
       ///
       /// See ``continuousClock`` to override a feature's `ContinuousClock`, instead.
       ///
-      /// [immediate-clock]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/immediateclock/
-      /// [test-clock]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/testclock/
+      /// [immediate-clock]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/immediateclock
+      /// [test-clock]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/testclock
       /// [swift-clocks]: https://github.com/pointfreeco/swift-clocks
-      /// [unimplemented-clock]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/unimplementedclock/
+      /// [unimplemented-clock]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/unimplementedclock
       public var suspendingClock: any Clock<Duration> {
         get { self[SuspendingClockKey.self] }
         set { self[SuspendingClockKey.self] = newValue }

--- a/Sources/Dependencies/Documentation.docc/Articles/LivePreviewTest.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/LivePreviewTest.md
@@ -303,7 +303,7 @@ func testFeature() {
 }
 ```
 
-[unimplemented-docs]: https://pointfreeco.github.io/xctest-dynamic-overlay/main/documentation/xctestdynamicoverlay/unimplemented(_:fileid:line:)-5098a
+[unimplemented-docs]: https://swiftpackageindex.com/pointfreeco/swift-issue-reporting/main/documentation/issuereporting/unimplemented(_:fileid:filepath:function:line:column:)
 [issue-reporting-gh]: http://github.com/pointfreeco/xctest-dynamic-overlay
 
 ## Topics

--- a/Sources/Dependencies/Documentation.docc/Articles/QuickStart.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/QuickStart.md
@@ -141,4 +141,4 @@ can do. You can learn more in depth about <doc:WhatAreDependencies> as well as
 there are more advanced topics to explore, such as <doc:DesigningDependencies>,
 <doc:OverridingDependencies>, <doc:Lifetimes> and <doc:SingleEntryPointSystems>.
 
-[immediate-clock-docs]: https://pointfreeco.github.io/swift-clocks/main/documentation/clocks/immediateclock
+[immediate-clock-docs]: https://swiftpackageindex.com/pointfreeco/swift-clocks/main/documentation/clocks/immediateclock


### PR DESCRIPTION
## Summary
- Replace stale pointfreeco.github.io DocC links with Swift Package Index documentation links.
- Update the Issue Reporting unimplemented link to the current SPI documentation path.

## Verification
- Checked that no files still reference pointfreeco.github.io.
- Ran git diff --check.