### PR TITLE
Force generated key to be nonisolated.

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -125,7 +125,7 @@ extension DependencyEntryMacro: PeerMacro {
 
     let body = members.joined(separator: "\n")
     let keyDecl: DeclSyntax = """
-      private enum \(keyName): Dependencies.\(raw: conformance) {
+      private nonisolated enum \(keyName): Dependencies.\(raw: conformance) {
       \(raw: body)
       }
       """

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -33,7 +33,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
           }
         }
 
-        private enum __Key_client: Dependencies.DependencyKey {
+        private nonisolated enum __Key_client: Dependencies.DependencyKey {
           @DependenciesMacros._DependencyEntryDefaultValue static var liveValue = Client.live
           @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
         }
@@ -62,7 +62,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
           }
         }
 
-        private enum __Key_client: Dependencies.DependencyKey {
+        private nonisolated enum __Key_client: Dependencies.DependencyKey {
           @DependenciesMacros._DependencyEntryDefaultValue static var liveValue = Client.live
           @DependenciesMacros._DependencyEntryDefaultValue static var previewValue = Client.preview
           @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
@@ -92,7 +92,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
           }
         }
 
-        private enum __Key_client: Dependencies.TestDependencyKey {
+        private nonisolated enum __Key_client: Dependencies.TestDependencyKey {
           @DependenciesMacros._DependencyEntryDefaultValue static var previewValue = Client.preview
           @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
         }
@@ -121,7 +121,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
           }
         }
 
-        private enum __Key_client: Dependencies.TestDependencyKey {
+        private nonisolated enum __Key_client: Dependencies.TestDependencyKey {
           @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
         }
       }
@@ -149,7 +149,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
           }
         }
 
-        private enum __Key_client: Dependencies.DependencyKey {
+        private nonisolated enum __Key_client: Dependencies.DependencyKey {
           typealias Value = Client
           static var liveValue: Value {
             Client.live
@@ -242,7 +242,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
           }
         }
 
-        private enum __Key_client: Dependencies.DependencyKey {
+        private nonisolated enum __Key_client: Dependencies.DependencyKey {
           typealias Value = Client
           static var liveValue: Value {
             Client.live


### PR DESCRIPTION
The new `@DependencyEntry` macro is not usable from main actor targets because the generated key is not `nonisolated`.