### PR TITLE
Support public entries with live value defined in separate module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+.swift-version

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "78636d694fb9f0167d899d76d37a5f6ae41810c557c442d816edadeaf19e317d",
+  "originHash" : "f171a17395c71a4cc28a00fe9f5d0dac8112abe5c378b4cbdc65a193bb83fb82",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     }
   ],

--- a/Sources/Dependencies/DependencyValues/FireAndForget.swift
+++ b/Sources/Dependencies/DependencyValues/FireAndForget.swift
@@ -66,7 +66,7 @@ public struct FireAndForget: Sendable {
 
 private enum FireAndForgetKey: DependencyKey {
   public static let liveValue = FireAndForget { priority, operation in
-    Task(priority: priority) { try await operation() }
+    _ = Task(priority: priority) { try await operation() }
   }
   public static let testValue = FireAndForget { priority, operation in
     await Task(priority: priority) { try? await operation() }.value

--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -236,6 +236,16 @@ public macro DependencyEndpointIgnored() =
 /// need to leave off the `liveValue` argument and instead provide the `liveValue` in your main
 /// app target, as described in <doc:LivePreviewTest:Separating-interface-and-implementation>.
 ///
+/// If you do not want to specify a `testValue`, then you can leave off the default value of the property as long as you supply
+/// either a `liveValue` or `previewValue`:
+///
+/// ```swift
+/// extension DependencyValues {
+///   @DependencyEntry(liveValue: LiveAPIClient())
+///   var apiClient: any APIClient
+/// }
+/// ```
+///
 /// - Parameters:
 ///   - keyName: An optional public key type name.
 ///   - liveValue: A live value.

--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -204,7 +204,7 @@ public macro DependencyEndpointIgnored() =
 /// }
 /// ```
 ///
-/// The macro will synthesize a private key type behind the scenes and generate the property's
+/// The macro will synthesize a dependency key type behind the scenes and generate the property's
 /// `get`/`set` accessors with the following rules:
 ///
 ///   * The value provided to the `@DependencyEntry` is used as the ``TestDependencyKey/testValue``
@@ -219,17 +219,38 @@ public macro DependencyEndpointIgnored() =
 ///       var apiClient: any APIClient = MockAPIClient()
 ///     }
 ///     ```
+///   * If a string is supplied as the first argument, then the synthesized key type is made public
+///     and uses that exact name:
+///
+///     ```swift
+///     extension DependencyValues {
+///       @DependencyEntry("APIClientKey")
+///       public var apiClient: any APIClient = MockAPIClient()
+///     }
+///     ```
+///   * If no explicit key name is supplied and the dependency entry itself is `public`, then the
+///     synthesized key type is made public and named after the property with `Key` appended. For
+///     example, `apiClient` becomes `ApiClientKey`.
 ///
 /// If you want to separate the live implementation from the interface of your dependency, you will
 /// need to leave off the `liveValue` argument and instead provide the `liveValue` in your main
 /// app target, as described in <doc:LivePreviewTest:Separating-interface-and-implementation>.
 ///
 /// - Parameters:
+///   - keyName: An optional public key type name.
 ///   - liveValue: A live value.
 ///   - previewValue: A preview value.
 @attached(accessor, names: named(get), named(set))
-@attached(peer, names: prefixed(__Key_))
+@attached(peer, names: arbitrary)
 public macro DependencyEntry<LiveValue, PreviewValue>(
+  liveValue: LiveValue = (),
+  previewValue: PreviewValue = ()
+) = #externalMacro(module: "DependenciesMacrosPlugin", type: "DependencyEntryMacro")
+
+@attached(accessor, names: named(get), named(set))
+@attached(peer, names: arbitrary)
+public macro DependencyEntry<LiveValue, PreviewValue>(
+  _ keyName: String,
   liveValue: LiveValue = (),
   previewValue: PreviewValue = ()
 ) = #externalMacro(module: "DependenciesMacrosPlugin", type: "DependencyEntryMacro")

--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -102,26 +102,26 @@ extension DependencyEntryMacro: PeerMacro {
 
     var members: [String] = []
     if let typeAnnotation = binding.typeAnnotation?.type.trimmed {
-      members.append("\(memberAccessLevel) typealias Value = \(typeAnnotation)")
+      members.append("\(memberAccessLevel)typealias Value = \(typeAnnotation)")
       if let liveValueExpr {
-        members.append("\(memberAccessLevel) static var liveValue: Value { \(liveValueExpr) }")
+        members.append("\(memberAccessLevel)static var liveValue: Value { \(liveValueExpr) }")
       }
       if let previewValueExpr {
-        members.append("\(memberAccessLevel) static var previewValue: Value { \(previewValueExpr) }")
+        members.append("\(memberAccessLevel)static var previewValue: Value { \(previewValueExpr) }")
       }
       if let testValueExpr {
-        members.append("\(memberAccessLevel) static var testValue: Value { \(testValueExpr) }")
+        members.append("\(memberAccessLevel)static var testValue: Value { \(testValueExpr) }")
       }
     } else {
       let attribute = "@DependenciesMacros._DependencyEntryDefaultValue"
       if let liveValueExpr {
-        members.append("\(attribute) \(memberAccessLevel) static var liveValue = \(liveValueExpr)")
+        members.append("\(attribute) \(memberAccessLevel)static var liveValue = \(liveValueExpr)")
       }
       if let previewValueExpr {
-        members.append("\(attribute) \(memberAccessLevel) static var previewValue = \(previewValueExpr)")
+        members.append("\(attribute) \(memberAccessLevel)static var previewValue = \(previewValueExpr)")
       }
       if let testValueExpr {
-        members.append("\(attribute) \(memberAccessLevel) static var testValue = \(testValueExpr)")
+        members.append("\(attribute) \(memberAccessLevel)static var testValue = \(testValueExpr)")
       }
     }
 
@@ -211,7 +211,7 @@ private func memberAccessLevel(
   else {
     return ""
   }
-  return "public"
+  return "public "
 }
 
 private func customKeyName(from node: AttributeSyntax) -> String? {

--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -118,7 +118,9 @@ extension DependencyEntryMacro: PeerMacro {
         members.append("\(attribute) \(memberAccessLevel)static var liveValue = \(liveValueExpr)")
       }
       if let previewValueExpr {
-        members.append("\(attribute) \(memberAccessLevel)static var previewValue = \(previewValueExpr)")
+        members.append(
+          "\(attribute) \(memberAccessLevel)static var previewValue = \(previewValueExpr)"
+        )
       }
       if let testValueExpr {
         members.append("\(attribute) \(memberAccessLevel)static var testValue = \(testValueExpr)")
@@ -140,36 +142,38 @@ private func keyTypeName(
   property: VariableDeclSyntax,
   identifier: TokenSyntax
 ) -> TokenSyntax {
+  guard property.isPublic
+  else {
+    return "__Key_\(identifier)"
+  }
   if let customKeyName = customKeyName(from: node) {
     return .identifier(customKeyName)
   }
-  if
-    let typeAnnotation = property.bindings.first?.typeAnnotation?.type,
+  if let typeAnnotation = property.bindings.first?.typeAnnotation?.type,
     let typeName = keyTypeName(from: typeAnnotation)
   {
     return .identifier("\(typeName)Key")
   }
-  if property.isPublic {
-    return .identifier("\(identifier.trimmedDescription.dependencyEntryTrimmedBackticks.uppercasingFirst)Key")
-  }
-  return "__Key_\(identifier)"
+  return .identifier(
+    "\(identifier.trimmedDescription.dependencyEntryTrimmedBackticks.uppercasingFirst)Key"
+  )
 }
 
 private func keyTypeName(from type: TypeSyntax) -> String? {
   switch type.as(TypeSyntaxEnum.self) {
-  case let .identifierType(type):
+  case .identifierType(let type):
     return type.name.text.dependencyEntryTrimmedBackticks
-  case let .memberType(type):
+  case .memberType(let type):
     return type.name.text.dependencyEntryTrimmedBackticks
-  case let .someOrAnyType(type):
+  case .someOrAnyType(let type):
     return keyTypeName(from: type.constraint)
-  case let .optionalType(type):
+  case .optionalType(let type):
     return keyTypeName(from: type.wrappedType)
-  case let .implicitlyUnwrappedOptionalType(type):
+  case .implicitlyUnwrappedOptionalType(let type):
     return keyTypeName(from: type.wrappedType)
-  case let .arrayType(type):
+  case .arrayType(let type):
     return keyTypeName(from: type.element)
-  case let .dictionaryType(type):
+  case .dictionaryType(let type):
     guard
       let keyType = keyTypeName(from: type.key),
       let valueType = keyTypeName(from: type.value)
@@ -177,15 +181,15 @@ private func keyTypeName(from type: TypeSyntax) -> String? {
       return nil
     }
     return "\(keyType)\(valueType)"
-  case let .tupleType(type):
+  case .tupleType(let type):
     let elements = type.elements.compactMap { keyTypeName(from: $0.type) }
     return elements.isEmpty ? nil : elements.joined()
-  case let .compositionType(type):
+  case .compositionType(let type):
     let elements = type.elements.compactMap { keyTypeName(from: $0.type) }
     return elements.isEmpty ? nil : elements.joined()
-  case let .attributedType(type):
+  case .attributedType(let type):
     return keyTypeName(from: type.baseType)
-  case let .metatypeType(type):
+  case .metatypeType(let type):
     return keyTypeName(from: type.baseType)
   default:
     return nil
@@ -268,14 +272,14 @@ extension DependencyEntryDefaultValueMacro: AccessorMacro {
   }
 }
 
-private extension VariableDeclSyntax {
-  var isPublic: Bool {
+extension VariableDeclSyntax {
+  fileprivate var isPublic: Bool {
     self.modifiers.contains { $0.name.tokenKind == .keyword(.public) }
   }
 }
 
-private extension String {
-  var dependencyEntryTrimmedBackticks: String {
+extension String {
+  fileprivate var dependencyEntryTrimmedBackticks: String {
     var result = self[...]
     if result.first == "`" {
       result = result.dropFirst()
@@ -286,7 +290,7 @@ private extension String {
     return String(result)
   }
 
-  var uppercasingFirst: String {
+  fileprivate var uppercasingFirst: String {
     guard let first else { return self }
     return first.uppercased() + dropFirst()
   }

--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -65,6 +65,7 @@ extension DependencyEntryMacro: PeerMacro {
     }
 
     let accessLevel = keyAccessLevel(for: node, property: property)
+    let memberAccessLevel = memberAccessLevel(for: node, property: property)
     var liveValueExpr: ExprSyntax?
     var previewValueExpr: ExprSyntax?
     if let arguments = node.arguments?.as(LabeledExprListSyntax.self) {
@@ -101,26 +102,26 @@ extension DependencyEntryMacro: PeerMacro {
 
     var members: [String] = []
     if let typeAnnotation = binding.typeAnnotation?.type.trimmed {
-      members.append("typealias Value = \(typeAnnotation)")
+      members.append("\(memberAccessLevel) typealias Value = \(typeAnnotation)")
       if let liveValueExpr {
-        members.append("static var liveValue: Value { \(liveValueExpr) }")
+        members.append("\(memberAccessLevel) static var liveValue: Value { \(liveValueExpr) }")
       }
       if let previewValueExpr {
-        members.append("static var previewValue: Value { \(previewValueExpr) }")
+        members.append("\(memberAccessLevel) static var previewValue: Value { \(previewValueExpr) }")
       }
       if let testValueExpr {
-        members.append("static var testValue: Value { \(testValueExpr) }")
+        members.append("\(memberAccessLevel) static var testValue: Value { \(testValueExpr) }")
       }
     } else {
       let attribute = "@DependenciesMacros._DependencyEntryDefaultValue"
       if let liveValueExpr {
-        members.append("\(attribute) static var liveValue = \(liveValueExpr)")
+        members.append("\(attribute) \(memberAccessLevel) static var liveValue = \(liveValueExpr)")
       }
       if let previewValueExpr {
-        members.append("\(attribute) static var previewValue = \(previewValueExpr)")
+        members.append("\(attribute) \(memberAccessLevel) static var previewValue = \(previewValueExpr)")
       }
       if let testValueExpr {
-        members.append("\(attribute) static var testValue = \(testValueExpr)")
+        members.append("\(attribute) \(memberAccessLevel) static var testValue = \(testValueExpr)")
       }
     }
 
@@ -152,10 +153,22 @@ private func keyAccessLevel(
   for node: AttributeSyntax,
   property: VariableDeclSyntax
 ) -> String {
-  if customKeyName(from: node) != nil || property.isPublic {
-    return "public"
+  guard customKeyName(from: node) != nil || property.isPublic
+  else {
+    return "private"
   }
-  return "private"
+  return "public"
+}
+
+private func memberAccessLevel(
+  for node: AttributeSyntax,
+  property: VariableDeclSyntax
+) -> String {
+  guard customKeyName(from: node) != nil || property.isPublic
+  else {
+    return ""
+  }
+  return "public"
 }
 
 private func customKeyName(from node: AttributeSyntax) -> String? {

--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -20,7 +20,7 @@ extension DependencyEntryMacro: AccessorMacro {
     else {
       return []
     }
-    let keyName: TokenSyntax = "__Key_\(identifier)"
+    let keyName = keyTypeName(for: node, property: property, identifier: identifier)
     return [
       """
       get { self[\(keyName).self] }
@@ -64,6 +64,7 @@ extension DependencyEntryMacro: PeerMacro {
       return []
     }
 
+    let accessLevel = keyAccessLevel(for: node, property: property)
     var liveValueExpr: ExprSyntax?
     var previewValueExpr: ExprSyntax?
     if let arguments = node.arguments?.as(LabeledExprListSyntax.self) {
@@ -96,7 +97,7 @@ extension DependencyEntryMacro: PeerMacro {
     }
 
     let conformance = liveValueExpr != nil ? "DependencyKey" : "TestDependencyKey"
-    let keyName: TokenSyntax = "__Key_\(identifier)"
+    let keyName = keyTypeName(for: node, property: property, identifier: identifier)
 
     var members: [String] = []
     if let typeAnnotation = binding.typeAnnotation?.type.trimmed {
@@ -125,12 +126,51 @@ extension DependencyEntryMacro: PeerMacro {
 
     let body = members.joined(separator: "\n")
     let keyDecl: DeclSyntax = """
-      private nonisolated enum \(keyName): Dependencies.\(raw: conformance) {
+      \(raw: accessLevel) nonisolated enum \(keyName): Dependencies.\(raw: conformance) {
       \(raw: body)
       }
       """
     return [keyDecl]
   }
+}
+
+private func keyTypeName(
+  for node: AttributeSyntax,
+  property: VariableDeclSyntax,
+  identifier: TokenSyntax
+) -> TokenSyntax {
+  if let customKeyName = customKeyName(from: node) {
+    return .identifier(customKeyName)
+  }
+  if property.isPublic {
+    return .identifier("\(identifier.trimmedDescription.dependencyEntryTrimmedBackticks.uppercasingFirst)Key")
+  }
+  return "__Key_\(identifier)"
+}
+
+private func keyAccessLevel(
+  for node: AttributeSyntax,
+  property: VariableDeclSyntax
+) -> String {
+  if customKeyName(from: node) != nil || property.isPublic {
+    return "public"
+  }
+  return "private"
+}
+
+private func customKeyName(from node: AttributeSyntax) -> String? {
+  guard let arguments = node.arguments?.as(LabeledExprListSyntax.self) else { return nil }
+  for argument in arguments where argument.label == nil {
+    guard
+      let literal = argument.expression.as(StringLiteralExprSyntax.self),
+      literal.segments.count == 1,
+      let segment = literal.segments.first?.as(StringSegmentSyntax.self)
+    else {
+      continue
+    }
+    return segment.content.text
+  }
+  return nil
 }
 
 private func isInDependencyValuesExtension(
@@ -169,5 +209,29 @@ extension DependencyEntryDefaultValueMacro: AccessorMacro {
       return []
     }
     return ["get { \(initializer) }"]
+  }
+}
+
+private extension VariableDeclSyntax {
+  var isPublic: Bool {
+    self.modifiers.contains { $0.name.tokenKind == .keyword(.public) }
+  }
+}
+
+private extension String {
+  var dependencyEntryTrimmedBackticks: String {
+    var result = self[...]
+    if result.first == "`" {
+      result = result.dropFirst()
+    }
+    if result.last == "`" {
+      result = result.dropLast()
+    }
+    return String(result)
+  }
+
+  var uppercasingFirst: String {
+    guard let first else { return self }
+    return first.uppercased() + dropFirst()
   }
 }

--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -142,7 +142,7 @@ private func keyTypeName(
   property: VariableDeclSyntax,
   identifier: TokenSyntax
 ) -> TokenSyntax {
-  guard property.isPublic
+  guard property.isPublicOrPackage
   else {
     return "__Key_\(identifier)"
   }
@@ -200,22 +200,24 @@ private func keyAccessLevel(
   for node: AttributeSyntax,
   property: VariableDeclSyntax
 ) -> String {
-  guard customKeyName(from: node) != nil || property.isPublic
+  guard customKeyName(from: node) != nil || property.isPublicOrPackage
   else {
     return "private"
   }
-  return "public"
+  return property.publicOrPackage ?? "private"
 }
 
 private func memberAccessLevel(
   for node: AttributeSyntax,
   property: VariableDeclSyntax
 ) -> String {
-  guard customKeyName(from: node) != nil || property.isPublic
+  guard let accessControl = property.publicOrPackage
   else {
-    return ""
+    guard customKeyName(from: node) != nil
+    else { return "" }
+    return "public "
   }
-  return "public "
+  return "\(accessControl) "
 }
 
 private func customKeyName(from node: AttributeSyntax) -> String? {
@@ -273,8 +275,18 @@ extension DependencyEntryDefaultValueMacro: AccessorMacro {
 }
 
 extension VariableDeclSyntax {
-  fileprivate var isPublic: Bool {
-    self.modifiers.contains { $0.name.tokenKind == .keyword(.public) }
+  fileprivate var isPublicOrPackage: Bool {
+    self.modifiers.contains {
+      $0.name.tokenKind == .keyword(.public)
+      || $0.name.tokenKind == .keyword(.package)
+    }
+  }
+  fileprivate var publicOrPackage: String? {
+    self.modifiers.first {
+      $0.name.tokenKind == .keyword(.public)
+      || $0.name.tokenKind == .keyword(.package)
+    }?.name.trimmedDescription
+
   }
 }
 

--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -143,10 +143,53 @@ private func keyTypeName(
   if let customKeyName = customKeyName(from: node) {
     return .identifier(customKeyName)
   }
+  if
+    let typeAnnotation = property.bindings.first?.typeAnnotation?.type,
+    let typeName = keyTypeName(from: typeAnnotation)
+  {
+    return .identifier("\(typeName)Key")
+  }
   if property.isPublic {
     return .identifier("\(identifier.trimmedDescription.dependencyEntryTrimmedBackticks.uppercasingFirst)Key")
   }
   return "__Key_\(identifier)"
+}
+
+private func keyTypeName(from type: TypeSyntax) -> String? {
+  switch type.as(TypeSyntaxEnum.self) {
+  case let .identifierType(type):
+    return type.name.text.dependencyEntryTrimmedBackticks
+  case let .memberType(type):
+    return type.name.text.dependencyEntryTrimmedBackticks
+  case let .someOrAnyType(type):
+    return keyTypeName(from: type.constraint)
+  case let .optionalType(type):
+    return keyTypeName(from: type.wrappedType)
+  case let .implicitlyUnwrappedOptionalType(type):
+    return keyTypeName(from: type.wrappedType)
+  case let .arrayType(type):
+    return keyTypeName(from: type.element)
+  case let .dictionaryType(type):
+    guard
+      let keyType = keyTypeName(from: type.key),
+      let valueType = keyTypeName(from: type.value)
+    else {
+      return nil
+    }
+    return "\(keyType)\(valueType)"
+  case let .tupleType(type):
+    let elements = type.elements.compactMap { keyTypeName(from: $0.type) }
+    return elements.isEmpty ? nil : elements.joined()
+  case let .compositionType(type):
+    let elements = type.elements.compactMap { keyTypeName(from: $0.type) }
+    return elements.isEmpty ? nil : elements.joined()
+  case let .attributedType(type):
+    return keyTypeName(from: type.baseType)
+  case let .metatypeType(type):
+    return keyTypeName(from: type.baseType)
+  default:
+    return nil
+  }
 }
 
 private func keyAccessLevel(

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -252,4 +252,62 @@ final class DependencyEntryMacroTests: BaseTestCase {
       """
     }
   }
+
+  func testPublicKeyName() {
+    assertMacro {
+      """
+      extension DependencyValues {
+        @DependencyEntry("APIClientKey", liveValue: Client.live)
+        public var client = Client.test
+      }
+      """
+    } expansion: {
+      """
+      extension DependencyValues {
+        public var client {
+          get {
+            self[APIClientKey.self]
+          }
+          set {
+            self[APIClientKey.self] = newValue
+          }
+        }
+
+        public nonisolated enum APIClientKey: Dependencies.DependencyKey {
+          @DependenciesMacros._DependencyEntryDefaultValue static var liveValue = Client.live
+          @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
+        }
+      }
+      """
+    }
+  }
+
+  func testPublicPropertyDerivesPublicKeyName() {
+    assertMacro {
+      """
+      extension DependencyValues {
+        @DependencyEntry(liveValue: Client.live)
+        public var client = Client.test
+      }
+      """
+    } expansion: {
+      """
+      extension DependencyValues {
+        public var client {
+          get {
+            self[ClientKey.self]
+          }
+          set {
+            self[ClientKey.self] = newValue
+          }
+        }
+
+        public nonisolated enum ClientKey: Dependencies.DependencyKey {
+          @DependenciesMacros._DependencyEntryDefaultValue static var liveValue = Client.live
+          @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
+        }
+      }
+      """
+    }
+  }
 }

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -274,8 +274,8 @@ final class DependencyEntryMacroTests: BaseTestCase {
         }
 
         public nonisolated enum APIClientKey: Dependencies.DependencyKey {
-          @DependenciesMacros._DependencyEntryDefaultValue static var liveValue = Client.live
-          @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
+          @DependenciesMacros._DependencyEntryDefaultValue public static var liveValue = Client.live
+          @DependenciesMacros._DependencyEntryDefaultValue public static var testValue = Client.test
         }
       }
       """
@@ -303,8 +303,39 @@ final class DependencyEntryMacroTests: BaseTestCase {
         }
 
         public nonisolated enum ClientKey: Dependencies.DependencyKey {
-          @DependenciesMacros._DependencyEntryDefaultValue static var liveValue = Client.live
-          @DependenciesMacros._DependencyEntryDefaultValue static var testValue = Client.test
+          @DependenciesMacros._DependencyEntryDefaultValue public static var liveValue = Client.live
+          @DependenciesMacros._DependencyEntryDefaultValue public static var testValue = Client.test
+        }
+      }
+      """
+    }
+  }
+
+  func testPublicPropertyWithExplicitKeyNameAndTypeAnnotation() {
+    assertMacro {
+      """
+      extension DependencyValues {
+        @DependencyEntry("APIClientKey")
+        public var client: any APIClient = MockAPIClient()
+      }
+      """
+    } expansion: {
+      """
+      extension DependencyValues {
+        public var client: any APIClient {
+          get {
+            self[APIClientKey.self]
+          }
+          set {
+            self[APIClientKey.self] = newValue
+          }
+        }
+
+        public nonisolated enum APIClientKey: Dependencies.TestDependencyKey {
+          public typealias Value = any APIClient
+          public static var testValue: Value {
+            MockAPIClient()
+          }
         }
       }
       """

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -142,14 +142,14 @@ final class DependencyEntryMacroTests: BaseTestCase {
       extension DependencyValues {
         var client: Client {
           get {
-            self[ClientKey.self]
+            self[__Key_client.self]
           }
           set {
-            self[ClientKey.self] = newValue
+            self[__Key_client.self] = newValue
           }
         }
 
-        private nonisolated enum ClientKey: Dependencies.DependencyKey {
+        private nonisolated enum __Key_client: Dependencies.DependencyKey {
           typealias Value = Client
           static var liveValue: Value {
             Client.live
@@ -235,14 +235,14 @@ final class DependencyEntryMacroTests: BaseTestCase {
       extension DependencyValues {
         var client: Client {
           get {
-            self[ClientKey.self]
+            self[__Key_client.self]
           }
           set {
-            self[ClientKey.self] = newValue
+            self[__Key_client.self] = newValue
           }
         }
 
-        private nonisolated enum ClientKey: Dependencies.DependencyKey {
+        private nonisolated enum __Key_client: Dependencies.DependencyKey {
           typealias Value = Client
           static var liveValue: Value {
             Client.live

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -142,14 +142,14 @@ final class DependencyEntryMacroTests: BaseTestCase {
       extension DependencyValues {
         var client: Client {
           get {
-            self[__Key_client.self]
+            self[ClientKey.self]
           }
           set {
-            self[__Key_client.self] = newValue
+            self[ClientKey.self] = newValue
           }
         }
 
-        private nonisolated enum __Key_client: Dependencies.DependencyKey {
+        private nonisolated enum ClientKey: Dependencies.DependencyKey {
           typealias Value = Client
           static var liveValue: Value {
             Client.live
@@ -235,14 +235,14 @@ final class DependencyEntryMacroTests: BaseTestCase {
       extension DependencyValues {
         var client: Client {
           get {
-            self[__Key_client.self]
+            self[ClientKey.self]
           }
           set {
-            self[__Key_client.self] = newValue
+            self[ClientKey.self] = newValue
           }
         }
 
-        private nonisolated enum __Key_client: Dependencies.DependencyKey {
+        private nonisolated enum ClientKey: Dependencies.DependencyKey {
           typealias Value = Client
           static var liveValue: Value {
             Client.live
@@ -316,6 +316,68 @@ final class DependencyEntryMacroTests: BaseTestCase {
       """
       extension DependencyValues {
         @DependencyEntry("APIClientKey")
+        public var client: any APIClient = MockAPIClient()
+      }
+      """
+    } expansion: {
+      """
+      extension DependencyValues {
+        public var client: any APIClient {
+          get {
+            self[APIClientKey.self]
+          }
+          set {
+            self[APIClientKey.self] = newValue
+          }
+        }
+
+        public nonisolated enum APIClientKey: Dependencies.TestDependencyKey {
+          public typealias Value = any APIClient
+          public static var testValue: Value {
+            MockAPIClient()
+          }
+        }
+      }
+      """
+    }
+  }
+
+  func testPublicPropertyWithImplicitKeyNameAndTypeAnnotation() {
+    assertMacro {
+      """
+      extension DependencyValues {
+        @DependencyEntry
+        public var client: MockAPIClient = MockAPIClient()
+      }
+      """
+    } expansion: {
+      """
+      extension DependencyValues {
+        public var client: MockAPIClient {
+          get {
+            self[MockAPIClientKey.self]
+          }
+          set {
+            self[MockAPIClientKey.self] = newValue
+          }
+        }
+
+        public nonisolated enum MockAPIClientKey: Dependencies.TestDependencyKey {
+          public typealias Value = MockAPIClient
+          public static var testValue: Value {
+            MockAPIClient()
+          }
+        }
+      }
+      """
+    }
+  }
+
+  func testPublicPropertyWithImplicitKeyNameAndExistentialTypeAnnotation() {
+    assertMacro {
+      """
+      extension DependencyValues {
+        @DependencyEntry
         public var client: any APIClient = MockAPIClient()
       }
       """

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -282,6 +282,34 @@ final class DependencyEntryMacroTests: BaseTestCase {
     }
   }
 
+  func testPackageKeyName() {
+    assertMacro {
+      """
+      extension DependencyValues {
+        @DependencyEntry
+        package var client = Client.test
+      }
+      """
+    } expansion: {
+      """
+      extension DependencyValues {
+        package var client {
+          get {
+            self[ClientKey.self]
+          }
+          set {
+            self[ClientKey.self] = newValue
+          }
+        }
+
+        package nonisolated enum ClientKey: Dependencies.TestDependencyKey {
+          @DependenciesMacros._DependencyEntryDefaultValue package static var testValue = Client.test
+        }
+      }
+      """
+    }
+  }
+
   func testPublicPropertyDerivesPublicKeyName() {
     assertMacro {
       """

--- a/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEntryMacroTests.swift
@@ -315,7 +315,7 @@ final class DependencyEntryMacroTests: BaseTestCase {
     assertMacro {
       """
       extension DependencyValues {
-        @DependencyEntry("APIClientKey")
+        @DependencyEntry("ExplicitAPIClientKey")
         public var client: any APIClient = MockAPIClient()
       }
       """
@@ -324,14 +324,14 @@ final class DependencyEntryMacroTests: BaseTestCase {
       extension DependencyValues {
         public var client: any APIClient {
           get {
-            self[APIClientKey.self]
+            self[ExplicitAPIClientKey.self]
           }
           set {
-            self[APIClientKey.self] = newValue
+            self[ExplicitAPIClientKey.self] = newValue
           }
         }
 
-        public nonisolated enum APIClientKey: Dependencies.TestDependencyKey {
+        public nonisolated enum ExplicitAPIClientKey: Dependencies.TestDependencyKey {
           public typealias Value = any APIClient
           public static var testValue: Value {
             MockAPIClient()

--- a/Tests/DependenciesMacrosPluginTests/MacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/MacroTests.swift
@@ -43,14 +43,25 @@ struct TestDependencyEntries {
 
 extension DependencyValues {
   @DependencyEntry("ExplicitAPIClientKey")
-  public var apiClientWithExplicitKeyName: any APIClient = MockAPIClient()
+  public var apiClientWithExplicitKeyName: any PublicAPIClient = PublicMockAPIClient()
 
   @DependencyEntry
-  public var apiClientWithImplicitKeyName = MockAPIClient()
+  public var apiClientWithImplicitKeyName = PublicMockAPIClient()
 
   @DependencyEntry
-  public var apiClientWithTypeSpecified: any APIClient = MockAPIClient()
+  public var apiClientWithTypeSpecified: any PublicAPIClient = PublicMockAPIClient()
+
+  @DependencyEntry("PackageExplicitAPIClientKey")
+  package var packageApiClientWithExplicitKeyName: any PackageAPIClient = PackageMockAPIClient()
+
+  @DependencyEntry
+  package var packageApiClientWithImplicitKeyName = PackageMockAPIClient()
+
+  @DependencyEntry
+  package var packageApiClientWithTypeSpecified: any PackageAPIClient = PackageMockAPIClient()
 }
 
-public protocol APIClient: Sendable {}
-public struct MockAPIClient: APIClient {}
+public protocol PublicAPIClient: Sendable {}
+public struct PublicMockAPIClient: PublicAPIClient {}
+package protocol PackageAPIClient: Sendable {}
+package struct PackageMockAPIClient: PackageAPIClient {}

--- a/Tests/DependenciesMacrosPluginTests/MacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/MacroTests.swift
@@ -42,7 +42,7 @@ struct TestDependencyEntries {
 
 
 extension DependencyValues {
-  @DependencyEntry("APIClientKey")
+  @DependencyEntry("ExplicitAPIClientKey")
   public var apiClientWithExplicitKeyName: any APIClient = MockAPIClient()
 
   @DependencyEntry

--- a/Tests/DependenciesMacrosPluginTests/MacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/MacroTests.swift
@@ -1,4 +1,4 @@
-import Dependencies
+public import Dependencies
 import DependenciesMacros
 import IssueReporting
 
@@ -39,3 +39,18 @@ struct TestDependencyEntries {
   @Dependency(\.entryPreviewAndTestValue) fileprivate var entryPreviewAndTestValue
   @Dependency(\.entryWithTypeAnnotation) fileprivate var entryWithTypeAnnotation
 }
+
+
+extension DependencyValues {
+  @DependencyEntry("APIClientKey")
+  public var apiClientWithExplicitKeyName: any APIClient = MockAPIClient()
+
+  @DependencyEntry
+  public var apiClientWithImplicitKeyName = MockAPIClient()
+
+  @DependencyEntry
+  public var apiClientWithTypeSpecified: any APIClient = MockAPIClient()
+}
+
+public protocol APIClient: Sendable {}
+public struct MockAPIClient: APIClient {}


### PR DESCRIPTION
Right now the `@DependencyEntry` macro doesn't play nicely with separating live implementations from the interface. This fixes that by making the generated key type public when dealing with public properties:

```swift
extension DependencyValues {
  @DepedencyEntry
  var apiClient: any APIClient = MockAPIClient()
  // Macro generates a 'public enum APIClientKey'
}
extension DependencyValues.ApiClientKey: DependencyKey {
  static var liveValue: any APIClient { … }
}
```

Or your can provide a string argument to `@DependencyEntry` to explicitly make the key public and give it a name:

```swift
extension DependencyValues {
  @DepedencyEntry("MyAPIClientKey")
  var apiClient: any APIClient = MockAPIClient()
}
extension DependencyValues.MyAPIClientKey: DependencyKey {
  static var liveValue: any APIClient { … }
}
```