### PR TITLE
Add SwiftSyntaxMacroExpansion import for older SwiftSyntax

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEntryMacro.swift
@@ -3,6 +3,10 @@ public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
+#if !canImport(SwiftSyntax600)
+  import SwiftSyntaxMacroExpansion
+#endif
+
 public enum DependencyEntryMacro {}
 
 extension DependencyEntryMacro: AccessorMacro {


### PR DESCRIPTION
Fixes a Cannot find 'MacroExpansionErrorMessage' in scope error when SwiftSyntax is less than 600

https://github.com/pointfreeco/swift-dependencies/issues/446