### PR TITLE
Adds the `FoundationNetworking` trait to Package@swift-6.0.swift

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -52,6 +52,7 @@ let package = Package(
         .define("Clocks"),
         .define("CombineSchedulers"),
         .define("Foundation"),
+        .define("FoundationNetworking"),
       ]
     ),
     .target(


### PR DESCRIPTION
Resolves [the discussion from Slack](https://pointfreecommunity.slack.com/archives/C04L2D0MNJH/p1781733403850059) where I was encountering a failed compile.
This trait was missing from Package@swift-6.0.swift, so older Xcode versions were missing the `\.urlSession` dependency key.