### PR TITLE
Move macro runtime support into Dependencies module

### DIFF
--- a/Sources/Dependencies/MacrosSupport.swift
+++ b/Sources/Dependencies/MacrosSupport.swift
@@ -1,0 +1,26 @@
+import IssueReporting
+
+public func _reportIssue(
+  _ message: @autoclosure () -> String? = nil,
+  fileID: StaticString = #fileID,
+  filePath: StaticString = #filePath,
+  line: UInt = #line,
+  column: UInt = #column
+) {
+  IssueReporting.reportIssue(
+    message(),
+    fileID: fileID,
+    filePath: filePath,
+    line: line,
+    column: column
+  )
+}
+
+/// The error thrown by "unimplemented" closures produced by ``DependencyEndpoint(method:)``
+public struct UnimplementedDependencyEndpoint: Error {
+  let endpoint: String
+
+  public init(_ endpoint: String) {
+    self.endpoint = endpoint
+  }
+}

--- a/Sources/DependenciesMacros/Macros.swift
+++ b/Sources/DependenciesMacros/Macros.swift
@@ -271,12 +271,3 @@ public macro _DependencyEntryDefaultValue() =
     module: "DependenciesMacrosPlugin",
     type: "DependencyEntryDefaultValueMacro"
   )
-
-/// The error thrown by "unimplemented" closures produced by ``DependencyEndpoint(method:)``
-public struct Unimplemented: Error {
-  let endpoint: String
-
-  public init(_ endpoint: String) {
-    self.endpoint = endpoint
-  }
-}

--- a/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyEndpointMacro.swift
@@ -98,7 +98,7 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
       if functionType.effectSpecifiers?.hasThrowsClause == true {
         unimplementedDefault.statements.append(
           """
-          throw DependenciesMacros.Unimplemented("\(raw: unescapedIdentifier)")
+          throw Dependencies.UnimplementedDependencyEndpoint("\(raw: unescapedIdentifier)")
           """
         )
       } else if functionType.isVoid {
@@ -121,7 +121,7 @@ public enum DependencyEndpointMacro: AccessorMacro, PeerMacro {
     }
     unimplementedDefault.statements.insert(
       #"""
-      IssueReporting.reportIssue("Unimplemented: '\(Self.self).\#(raw: unescapedIdentifier)'")
+      Dependencies._reportIssue("Unimplemented: '\(Self.self).\#(raw: unescapedIdentifier)'")
       """#,
       at: unimplementedDefault.statements.startIndex
     )

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientMacroTests.swift
@@ -830,8 +830,8 @@ final class DependencyClientMacroTests: BaseTestCase {
         }
 
         @available(iOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(macOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(tvOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(watchOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") private var _fetch: (_ id: Int) throws -> String = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).fetch'")
-          throw DependenciesMacros.Unimplemented("fetch")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).fetch'")
+          throw Dependencies.UnimplementedDependencyEndpoint("fetch")
         }
 
         init(
@@ -874,8 +874,8 @@ final class DependencyClientMacroTests: BaseTestCase {
         }
 
         @available(iOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(macOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(tvOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") @available(watchOS, deprecated: 9999, message: "This property has a method equivalent that is preferred for autocomplete via this deprecation. It is perfectly fine to use for overriding and accessing via '@Dependency'.") private var _fetch: (_ id: Int) throws -> String = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).fetch'")
-          throw DependenciesMacros.Unimplemented("fetch")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).fetch'")
+          throw Dependencies.UnimplementedDependencyEndpoint("fetch")
         }
 
         init(
@@ -912,8 +912,8 @@ final class DependencyClientMacroTests: BaseTestCase {
         }
 
         private var _fetch: (Int) throws -> String = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).fetch'")
-          throw DependenciesMacros.Unimplemented("fetch")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).fetch'")
+          throw Dependencies.UnimplementedDependencyEndpoint("fetch")
         }
 
         init(

--- a/Tests/DependenciesMacrosPluginTests/DependencyClientTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyClientTests.swift
@@ -1,4 +1,5 @@
 #if canImport(ObjectiveC)
+  import Dependencies
   import DependenciesMacros
   import IssueReporting
   import XCTest
@@ -16,7 +17,9 @@
       do {
         let _ = try client.fetch()
         XCTFail("Client.fetch should throw an error.")
+      } catch is Dependencies.UnimplementedDependencyEndpoint {
       } catch {
+        XCTFail("Expected UnimplementedDependencyEndpoint, got \(error).")
       }
     }
 

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointMacroTests.swift
@@ -34,7 +34,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Void = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -62,7 +62,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Bool = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
           return false
         }
       }
@@ -112,7 +112,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Bool = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
           return <#Bool#>
         }
       }
@@ -162,7 +162,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: (Int, Bool, String) -> Bool = { _, _, _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
           return <#Bool#>
         }
       }
@@ -191,8 +191,8 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () throws -> Bool = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
-          throw DependenciesMacros.Unimplemented("endpoint")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          throw Dependencies.UnimplementedDependencyEndpoint("endpoint")
         }
       }
       """#
@@ -220,8 +220,8 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _apiRequest: @Sendable (ServerRoute.Api.Route) async throws -> (Data, URLResponse) = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).apiRequest'")
-          throw DependenciesMacros.Unimplemented("apiRequest")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).apiRequest'")
+          throw Dependencies.UnimplementedDependencyEndpoint("apiRequest")
         }
       }
       """#
@@ -249,7 +249,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> () = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -277,7 +277,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Int? = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
           return nil
         }
       }
@@ -306,7 +306,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Optional<Int> = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
           return nil
         }
       }
@@ -335,7 +335,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: @Sendable (Int) -> Void = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -368,7 +368,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: @Sendable (String, _ id: Int, _ progress: Float) async -> Void = { _, _, _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -401,7 +401,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: @MainActor @Sendable (_ id: Int) async -> Void = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -434,7 +434,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: @Sendable (_ id: Int) async -> Void = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -466,7 +466,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: (_ id: Int) -> Void = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -498,7 +498,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Void = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -550,7 +550,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: (_ id: Int) -> Void = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -595,8 +595,8 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       }
 
       private var _return: () throws -> Int = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).return'")
-          throw DependenciesMacros.Unimplemented("return")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).return'")
+          throw Dependencies.UnimplementedDependencyEndpoint("return")
       }
       """#
     }
@@ -624,8 +624,8 @@ final class DependencyEndpointMacroTests: BaseTestCase {
       }
 
       private var _return: (_ id: Int) throws -> Int = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).return'")
-          throw DependenciesMacros.Unimplemented("return")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).return'")
+          throw Dependencies.UnimplementedDependencyEndpoint("return")
       }
       """#
     }
@@ -679,7 +679,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _doAThing: (_ value: Int) -> String = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).doAThing'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).doAThing'")
           return "Hello, world"
           }
       }
@@ -714,7 +714,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _doAThing: (_ a: inout Int, _ b: Int, _ c: inout Bool) -> String = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).doAThing'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).doAThing'")
           return "Hello, world"
           }
       }
@@ -747,7 +747,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _bar: (_ a: @autoclosure () -> Int, _ b: () -> Int, _ c: @autoclosure () -> Int) -> Void = { _, _, _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).bar'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).bar'")
         }
       }
       """#
@@ -817,7 +817,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _foo: () -> Void = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).foo'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).foo'")
           return {
             fatalError()
           }()
@@ -832,7 +832,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _bar: () -> String = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).bar'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).bar'")
           return {
             fatalError("Goodbye")
           }()
@@ -871,8 +871,8 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _foo: () throws -> Void = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).foo'")
-          throw DependenciesMacros.Unimplemented("foo")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).foo'")
+          throw Dependencies.UnimplementedDependencyEndpoint("foo")
         } {
             willSet {
               print("!")
@@ -904,7 +904,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Void = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -936,7 +936,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: (_ id: Int) -> Void = { _ in
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#
@@ -964,7 +964,7 @@ final class DependencyEndpointMacroTests: BaseTestCase {
         }
 
         private var _endpoint: () -> Void = {
-          IssueReporting.reportIssue("Unimplemented: '\(Self.self).endpoint'")
+          Dependencies._reportIssue("Unimplemented: '\(Self.self).endpoint'")
         }
       }
       """#

--- a/Tests/DependenciesMacrosPluginTests/DependencyEndpointTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/DependencyEndpointTests.swift
@@ -1,7 +1,6 @@
 #if canImport(DependenciesMacros)
   import Dependencies
   import DependenciesMacros
-  import IssueReporting
   import XCTest
 
   final class DependencyEndpointTests: XCTestCase {

--- a/Tests/DependenciesMacrosPluginTests/MacroTests.swift
+++ b/Tests/DependenciesMacrosPluginTests/MacroTests.swift
@@ -1,6 +1,5 @@
 public import Dependencies
 import DependenciesMacros
-import IssueReporting
 
 private enum PackageACL {
   @DependencyClient


### PR DESCRIPTION
This PR moves runtime support used by generated `@DependencyClient`/`@DependencyEndpoint` macro code into the `Dependencies` module. The current macro generated code introduces linkage dependencies on both `IssueReporting` and `DependeniesMacros` requiring clients to import both when using a dependency that was generated with the macros.

This consolidates all such macro runtime dependencies into the `MacrosSupport.swift` file in the `Dependencies` module. This reduces the client import surface to just `Dependencies` when using a macro-generated client. It must also now be imported when declaring a macro-generated dependency using `@DependencyClient` and related macros. In most common usage scenarios, it would normally already be imported to access `DependencyValues`, `TestDependencyKey`, etc., but this is a potentially breaking change and should be noted if released.

### Summary of Changes
- Add `Dependencies._reportIssue` as a small wrapper around `IssueReporting.reportIssue`.
- Add `Dependencies.UnimplementedDependencyEndpoint` to replace `DependenciesMacros.Unimplemented` in generated throwing endpoint defaults.
- Update generated macro code to reference `Dependencies` instead of `IssueReporting` / `DependenciesMacros` directly.
- Remove the runtime-only `Unimplemented` type from `DependenciesMacros`.
- Update macro tests and add coverage for the concrete thrown error type.

### Not Addressed
- The existing `DependenciesMacros.Unimplemented` was removed and not deprecated. This could potentially be an issue for users who were explicitly catching the exception type. But leaving it creates some cruft and it seems to mostly be an internal type (there was no existing test coverage for it).

### Validation
- `swift test`
- `make test-swift`