### PR TITLE
Add Swift 6.1 package manifest

### DIFF
--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -1,0 +1,149 @@
+// swift-tools-version: 6.1
+
+import CompilerPluginSupport
+import PackageDescription
+
+let package = Package(
+  name: "swift-dependencies",
+  platforms: [
+    .iOS(.v13),
+    .macOS(.v10_15),
+    .tvOS(.v13),
+    .watchOS(.v6),
+  ],
+  products: [
+    .library(
+      name: "Dependencies",
+      targets: ["Dependencies"]
+    ),
+    .library(
+      name: "DependenciesMacros",
+      targets: ["DependenciesMacros"]
+    ),
+    .library(
+      name: "DependenciesTestSupport",
+      targets: ["DependenciesTestSupport"]
+    ),
+  ],
+  traits: [
+    "Clocks",
+    "CombineSchedulers",
+    "Foundation",
+    "FoundationNetworking",
+    .default(enabledTraits: [
+      "Clocks", "CombineSchedulers", "Foundation", "FoundationNetworking",
+    ]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.2"),
+    .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.4"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
+  ],
+  targets: [
+    .target(
+      name: "DependenciesTestObserver",
+      dependencies: [
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay")
+      ]
+    ),
+    .target(
+      name: "Dependencies",
+      dependencies: [
+        .product(
+          name: "Clocks",
+          package: "swift-clocks",
+          condition: .when(traits: ["Clocks"])
+        ),
+        .product(
+          name: "CombineSchedulers",
+          package: "combine-schedulers",
+          condition: .when(traits: ["CombineSchedulers"])
+        ),
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("MemberImportVisibility")
+      ]
+    ),
+    .target(
+      name: "DependenciesTestSupport",
+      dependencies: [
+        "Dependencies",
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
+        .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
+      ]
+    ),
+    .testTarget(
+      name: "DependenciesTests",
+      dependencies: [
+        "Dependencies",
+        "DependenciesTestSupport",
+        .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
+      ],
+      exclude: ["Dependencies.xctestplan"]
+    ),
+    .target(
+      name: "DependenciesMacros",
+      dependencies: [
+        "DependenciesMacrosPlugin",
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+      ]
+    ),
+    .macro(
+      name: "DependenciesMacrosPlugin",
+      dependencies: [
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+      ]
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)
+
+#if !os(macOS) && !os(WASI)
+  package.products.append(
+    .library(
+      name: "DependenciesTestObserver",
+      type: .dynamic,
+      targets: ["DependenciesTestObserver"]
+    )
+  )
+#endif
+
+#if !os(WASI)
+  package.dependencies.append(
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0")
+  )
+  package.targets.append(contentsOf: [
+    .testTarget(
+      name: "DependenciesMacrosPluginTests",
+      dependencies: [
+        "Dependencies",
+        "DependenciesMacros",
+        "DependenciesMacrosPlugin",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    )
+  ])
+#endif
+
+#if !os(Windows)
+  // Add the documentation compiler plugin if possible
+  package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+  )
+#endif
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+  ])
+}


### PR DESCRIPTION
As discussed in https://github.com/pointfreeco/swift-sharing/pull/215#issuecomment-4879104261, this adds `Package@swift-6.1.swift` so Swift 6.1 and Swift 6.2 toolchains can resolve the package while the primary manifest uses Swift tools 6.3.

The manifest mirrors the current package setup, including package traits, and only enables upcoming features available to Swift 6.1.

## Verification

Selected Xcode 26.3 and ran:

- `make test-swift`
- `swift package dump-package | jq '.toolsVersion'` confirmed the selected manifest reports tools version `6.1.0`
