### PR TITLE
Drop swift-tools-version to 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.1
 
 import CompilerPluginSupport
 import PackageDescription


### PR DESCRIPTION
Nothing in the Package.swift requires 6.3, and we technically support 6.0, too.