### PR TITLE
Bring back preview traits

### DIFF
--- a/Integration/Integration.xcodeproj/project.pbxproj
+++ b/Integration/Integration.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -390,7 +390,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Integration/Integration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Integration/Integration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,30 +1,13 @@
 {
+  "originHash" : "6baa1ae507ac874d96a72249c7d932676c0e06a76f90e7315243e93b35141b69",
   "pins" : [
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
-      }
-    },
-    {
-      "identity" : "swift-benchmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/swift-benchmark",
-      "state" : {
-        "revision" : "8163295f6fe82356b0bcf8e1ab991645de17d096",
-        "version" : "0.1.2"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -32,8 +15,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
       }
     },
     {
@@ -55,14 +56,41 @@
       }
     },
     {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "62041e6016a30f56952f5d7d3f12a3fd7029e1cd",
-        "version" : "0.8.3"
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Integration/Integration/IntegrationApp.swift
+++ b/Integration/Integration/IntegrationApp.swift
@@ -51,3 +51,14 @@ struct IntegrationContextView: View {
 ) {
   IntegrationContextView()
 }
+
+#Preview(
+  "Third",
+  traits: .dependencies { _ in
+    struct Failure: Error {}
+    print(#line, "Third")
+    throw Failure()
+  }
+) {
+  IntegrationContextView()
+}

--- a/Integration/Integration/IntegrationApp.swift
+++ b/Integration/Integration/IntegrationApp.swift
@@ -18,5 +18,36 @@ private enum IntegrationContextKey: DependencyKey {
   static let testValue = "Test"
 }
 extension DependencyValues {
-  var integrationContext: String { self[IntegrationContextKey.self] }
+  var integrationContext: String {
+    get { self[IntegrationContextKey.self] }
+    set { self[IntegrationContextKey.self] = newValue }
+  }
+}
+
+struct IntegrationContextView: View {
+  @Dependency(\.integrationContext) var integrationContext
+  var body: some View {
+    Text(self.integrationContext)
+      .font(.system(size: 100))
+  }
+}
+
+#Preview(
+  "First",
+  traits: .dependencies {
+    $0.integrationContext = "First"
+    print(#line, $0.integrationContext)
+  }
+) {
+  IntegrationContextView()
+}
+
+#Preview(
+  "Second",
+  traits: .dependencies {
+    $0.integrationContext = "Second"
+    print(#line, $0.integrationContext)
+  }
+) {
+  IntegrationContextView()
 }

--- a/README.md
+++ b/README.md
@@ -169,15 +169,12 @@ and `UUID()`, and we'd have to wait for real world time to pass, making the test
 But, controllable dependencies aren't only useful for tests. They can also be used in Xcode
 previews. Suppose the feature above makes use of a clock to sleep for an amount of time before
 something happens in the view. If you don't want to literally wait for time to pass in order to see
-how the view changes, you can override the clock dependency to be an "immediate" clock using
-`prepareDependencies`:
+how the view changes, you can override the clock dependency to be an "immediate" clock using the
+`.dependencies` preview trait:
 
 ```swift
-#Preview {
-  let _ = prepareDependencies {
-    $0.continuousClock = ImmediateClock()
-  }
-  // All access of '@Dependency(\.continuousClock)' in this preview will 
+#Preview(traits: .dependencies { $0.continuousClock = ImmediateClock() }) {
+  // All access of '@Dependency(\.continuousClock)' in this preview will
   // use an immediate clock.
   FeatureView(model: FeatureModel())
 }

--- a/Sources/Dependencies/Documentation.docc/Articles/Lifetimes.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/Lifetimes.md
@@ -218,10 +218,11 @@ feature behaves in very specific states. For example, if you wanted to see how y
 when the `fetchUser` endpoint throws an error, you can update the preview like so:
 
 ```swift
-#Preview {
-  let _ = prepareDependencies {
+#Preview(
+  traits: .dependencies {
     $0.apiClient.fetchUser = { _ in throw SomeError() }
   }
+) {
   FeatureView(model: FeatureModel())
 }
 ```

--- a/Sources/Dependencies/Documentation.docc/Articles/LivePreviewTest.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/LivePreviewTest.md
@@ -174,40 +174,46 @@ data provided to it, making it easier for you to iterate on your feature's logic
 
 You can also always override dependencies for the preview if you want to test out a specific 
 configuration of data. For example, if you want to test the empty state of your feature when the 
-API client returns an empty array, you can do so like this:
+API client returns an empty array, you can use the 
+``DeveloperToolsSupport/PreviewTrait/dependencies(_:)`` preview trait:
 
 ```swift
-struct Feature_Previews: PreviewProvider {
-  static var previews: some View {
-    FeatureView(
-      model: withDependencies {
-        $0.apiClient.fetchUsers = { _ in [] }
-      } operation: {
-        FeatureModel()
-      }
-    )
+#Preview(
+  traits: .dependencies {
+    $0.apiClient.fetchUsers = { _ in [] }
   }
+) {
+  FeatureView(model: FeatureModel())
 }
 ```
 
 Or if you want to preview how your feature deals with errors returned from the API:
 
 ```swift
-struct Feature_Previews: PreviewProvider {
-  static var previews: some View {
-    FeatureView(
-      model: withDependencies {
-        $0.apiClient.fetchUser = { _ in
-          struct SomeError: Error {}
-          throw SomeError()
-        }
-      } operation: {
-        FeatureModel()
-      }
-    )
+#Preview(
+  traits: .dependencies {
+    $0.apiClient.fetchUser = { _ in
+      struct SomeError: Error {}
+      throw SomeError()
+    }
   }
+) {
+  FeatureView(model: FeatureModel())
 }
 ```
+
+> Note: The `.dependencies` preview trait requires iOS 18, macOS 15, tvOS 18, watchOS 11, or
+> visionOS 2. If your deployment target is earlier than that, you can invoke
+> ``prepareDependencies(_:)`` from the body of the preview, instead:
+>
+> ```swift
+> #Preview {
+>   let _ = prepareDependencies {
+>     $0.apiClient.fetchUsers = { _ in [] }
+>   }
+>   FeatureView(model: FeatureModel())
+> }
+> ```
 
 ## Separating interface and implementation
 

--- a/Sources/Dependencies/Documentation.docc/Articles/QuickStart.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/QuickStart.md
@@ -121,12 +121,11 @@ and `UUID()`, and we'd have to wait for real world time to pass, making the test
 But, controllable dependencies aren't only useful for tests. They can also be used in Xcode
 previews. Suppose the feature above makes use of a clock to sleep for an amount of time before
 something happens in the view. If you don't want to literally wait for time to pass in order to see
-how the view changes, you can override the clock dependency to be an "immediate" clock using
-``prepareDependencies(_:)``:
+how the view changes, you can override the clock dependency to be an "immediate" clock using the
+``DeveloperToolsSupport/PreviewTrait/dependencies(_:)`` preview trait:
 
 ```swift
-#Preview {
-  let _ = prepareDependencies { $0.continuousClock = ImmediateClock() }
+#Preview(traits: .dependencies { $0.continuousClock = ImmediateClock() }) {
   // All access of '@Dependency(\.continuousClock)' in this preview will
   // use an immediate clock.
   FeatureView(model: FeatureModel())

--- a/Sources/Dependencies/Documentation.docc/Articles/WhatAreDependencies.md
+++ b/Sources/Dependencies/Documentation.docc/Articles/WhatAreDependencies.md
@@ -99,13 +99,12 @@ final class FeatureModel {
 
 That small change makes this feature much friendlier to Xcode previews and testing.
 
-For previews, you can use ``prepareDependencies(_:)`` to override the
-``DependencyValues/continuousClock`` dependency to be an "immediate" clock, which is a clock that
-does not actually sleep for any amount of time:
+For previews, you can use the ``DeveloperToolsSupport/PreviewTrait/dependencies(_:)`` preview
+trait to override the ``DependencyValues/continuousClock`` dependency to be an "immediate" clock,
+which is a clock that does not actually sleep for any amount of time:
 
 ```swift
-#Preview {
-  let _ = prepareDependencies { $0.continuousClock = ImmediateClock() }
+#Preview(traits: .dependencies { $0.continuousClock = ImmediateClock() }) {
   FeatureView(model: FeatureModel())
 }
 ```

--- a/Sources/Dependencies/Internal/Deprecations.swift
+++ b/Sources/Dependencies/Internal/Deprecations.swift
@@ -9,12 +9,7 @@ public import ConcurrencyExtras
 #if canImport(SwiftUI) && compiler(>=6)
   @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
   extension PreviewTrait where T == Preview.ViewTraits {
-    @available(
-      *, deprecated,
-      message: """
-        Use 'withDependencies' or 'prepareDependencies' from the body of the preview, instead.
-        """
-    )
+    @available(*, deprecated, message: "Use '.dependencies' instead.")
     public static func dependency<Value>(
       _ keyPath: any WritableKeyPath<DependencyValues, Value> & Sendable,
       _ value: @autoclosure @escaping @Sendable () throws -> Value
@@ -22,59 +17,11 @@ public import ConcurrencyExtras
       .dependencies { $0[keyPath: keyPath] = try value() }
     }
 
-    @available(
-      *, deprecated,
-      message: """
-        Use 'withDependencies' or 'prepareDependencies' from the body of the preview, instead.
-        """
-    )
+    @available(*, deprecated, message: "Use '.dependencies' instead.")
     public static func dependency<Value: TestDependencyKey>(
       _ value: @autoclosure @escaping @Sendable () throws -> Value
     ) -> PreviewTrait where Value == Value.Value {
       .dependencies { $0[Value.self] = try value() }
-    }
-
-    @available(
-      *, deprecated,
-      message: """
-        Use 'withDependencies' or 'prepareDependencies' from the body of the preview, instead.
-        """
-    )
-    public static func dependencies(
-      _ updateValuesForPreview: @escaping @Sendable (inout DependencyValues) throws -> Void
-    ) -> PreviewTrait {
-      return .modifier(DependenciesPreviewModifier(updateValuesForPreview: updateValuesForPreview))
-    }
-  }
-
-  private struct DependenciesPreviewModifier: PreviewModifier {
-    let updateValuesForPreview: @Sendable (inout DependencyValues) throws -> Void
-
-    func body(content: Content, context: ()) -> some View {
-      let error: (any Error)? = {
-        do {
-          try prepareDependencies(updateValuesForPreview)
-          return nil
-        } catch {
-          return error
-        }
-      }()
-      ZStack {
-        content
-        if let error {
-          VStack {
-            Text("Preview Trait Failure")
-              .font(.headline.bold())
-            Text(error.localizedDescription)
-              .font(.subheadline)
-          }
-          .foregroundColor(Color.white)
-          .padding()
-          .background(Color.red)
-          .cornerRadius(8)
-          .opacity(0.75)
-        }
-      }
     }
   }
 #endif

--- a/Sources/Dependencies/Traits/PreviewTrait.swift
+++ b/Sources/Dependencies/Traits/PreviewTrait.swift
@@ -19,6 +19,14 @@
     /// }
     /// ```
     ///
+    /// Before applying the overrides, this trait resets all cached dependencies back to their
+    /// defaults so that multiple previews in a single file do not interfere with each other. For
+    /// this reason, use at most one `.dependencies` trait per preview: a second trait's reset
+    /// would discard the first trait's overrides.
+    ///
+    /// If the closure throws, the error is rendered directly in the preview instead of crashing
+    /// it.
+    ///
     /// - Parameter updateValuesForPreview: A closure for updating the current dependency values
     ///   for the lifetime of the preview.
     public static func dependencies(

--- a/Sources/Dependencies/Traits/PreviewTrait.swift
+++ b/Sources/Dependencies/Traits/PreviewTrait.swift
@@ -1,1 +1,62 @@
+#if canImport(SwiftUI) && compiler(>=6)
+  public import SwiftUI
 
+  @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
+  extension PreviewTrait where T == Preview.ViewTraits {
+    /// A trait that overrides a preview's dependencies.
+    ///
+    /// Useful for overriding several dependencies in a preview without incurring the nesting and
+    /// indentation of ``withDependencies(_:operation:)-4uz6m``.
+    ///
+    /// ```swift
+    /// #Preview(
+    ///   traits: .dependencies {
+    ///     $0.continuousClock = ImmediateClock()
+    ///     $0.date.now = Date(timeIntervalSince1970: 1234567890)
+    ///   }
+    /// ) {
+    ///   TimerView()
+    /// }
+    /// ```
+    ///
+    /// - Parameter updateValuesForPreview: A closure for updating the current dependency values
+    ///   for the lifetime of the preview.
+    public static func dependencies(
+      _ updateValuesForPreview: (inout DependencyValues) throws -> Void
+    ) -> PreviewTrait {
+      let error: (any Error)? = {
+        do {
+          DependencyValues._current.cachedValues.resetCache()
+          try prepareDependencies(updateValuesForPreview)
+          return nil
+        } catch {
+          return error
+        }
+      }()
+      return .modifier(DependenciesPreviewModifier(error: error))
+    }
+  }
+
+  private struct DependenciesPreviewModifier: PreviewModifier {
+    let error: (any Error)?
+
+    func body(content: Content, context: ()) -> some View {
+      ZStack {
+        content
+        if let error {
+          VStack {
+            Text("Preview Trait Failure")
+              .font(.headline.bold())
+            Text(error.localizedDescription)
+              .font(.subheadline)
+          }
+          .foregroundColor(Color.white)
+          .padding()
+          .background(Color.red)
+          .cornerRadius(8)
+          .opacity(0.75)
+        }
+      }
+    }
+  }
+#endif

--- a/Sources/Dependencies/WithDependencies.swift
+++ b/Sources/Dependencies/WithDependencies.swift
@@ -48,8 +48,22 @@ import IssueReporting
 /// > before it has been accessed. If you attempt to prepare a dependency that has previously been
 /// > overridden or accessed, a runtime warning will be emitted.
 ///
-/// You can also use ``prepareDependencies(_:)`` in Xcode previews, but you do have to use
-/// `let _` in order to play nicely with result builders:
+/// In Xcode previews, prefer the ``DeveloperToolsSupport/PreviewTrait/dependencies(_:)`` preview
+/// trait:
+///
+/// ```swift
+/// #Preview(
+///   traits: .dependencies {
+///     $0.defaultDatabase = try DatabaseQueue(/* ... */)
+///   }
+/// ) {
+///   FeatureView()
+/// }
+/// ```
+///
+/// If your deployment target is earlier than the trait supports (iOS 18, macOS 15, tvOS 18,
+/// watchOS 11, visionOS 2), you can use ``prepareDependencies(_:)`` in the preview's body, but
+/// you do have to use `let _` in order to play nicely with result builders:
 ///
 /// ```swift
 /// #Preview {


### PR DESCRIPTION
We previously introduced preview traits (#274), then deprecated them (#323), then reintroduced them (#353), and then re-deprecated them (#368). And we are ready to tempt the fates again by un-deprecating them again.

The fix this time is any idea from #463 where we reset the dependencies cache every time a preview trait is run. This will prevent one preview from bleeding out to another in the same file.

We'll see if this one sticks!